### PR TITLE
docs(api): design issue API extensions and domain sub-client architecture

### DIFF
--- a/docs/adr/ADR-002-auto-pagination-strategy.md
+++ b/docs/adr/ADR-002-auto-pagination-strategy.md
@@ -1,0 +1,145 @@
+# ADR-002: Auto-Pagination Strategy for Issue Comment Listing
+
+Status: Accepted
+Date: 2026-04-04
+Owners: github-bot-sdk team
+
+## Context
+
+The SDK exposes two conceptually similar list operations that serve different caller needs:
+
+1. **`list_issues()`** – callers may want to scroll through a large repository's issues page-by-page,
+   filtering interactively, and stopping early once they have what they need.
+2. **`list_issue_comments()`** – callers (e.g. `cog_works`) must read _all_ comments to find the
+   most recent state snapshot or detect a lock prefix. Stopping mid-page yields an incorrect result.
+
+GitHub returns paginated results for both endpoints (up to 100 items per page via `per_page=100`),
+signalling further pages via `Link: <url>; rel="next"` headers as per RFC 5988.
+
+The existing `list_issue_comments()` only fetches the first page, making it unusable for the
+cog_works pipeline-state and processing-lock use cases described in issue #39.
+
+Two competing patterns already exist in the SDK:
+
+| Pattern | Return type | Pagination control | Use case |
+|---------|------------|-------------------|----------|
+| Manual paging | `PagedResponse<T>` | Caller decides when to stop | Large lists, early termination |
+| Auto-pagination | `Vec<T>` | SDK follows all pages | Always-complete lists |
+
+## Decision
+
+Use **auto-pagination** (returning `Vec<T>`) for operations where **callers need the complete set**
+to make a correct decision, and **manual paging** (`PagedResponse<T>`) for operations where callers
+may legitimately stop early.
+
+**Criteria for auto-pagination:**
+
+- The calling use case requires inspecting _all_ items (not a subset).
+- Returning a partial list produces incorrect behaviour in the caller.
+- The total volume is bounded in practice (issue comments rarely exceed thousands).
+
+**Criteria for manual paging:**
+
+- Callers may want to stop early (e.g. "find the first open issue assigned to me").
+- The collection can be very large (e.g. all repository issues).
+- The caller needs to resume from a known page (e.g. cursor-based processing).
+
+**Applied to this SDK:**
+
+| Method | Return | Rationale |
+|--------|--------|-----------|
+| `list_issues()` | `PagedResponse<Issue>` | May stop early; large repos have thousands |
+| `list_issue_comments()` | `Vec<Comment>` | Must read all; use cases require complete list |
+| `list_labels()` | `Vec<Label>` | Small set, complete view always needed |
+| `list_milestones()` | `Vec<Milestone>` | Small set, complete view always needed |
+| `list_available_assignees()` | `Vec<IssueUser>` | Small set, complete view always needed |
+| `list_issue_reactions()` | `Vec<Reaction>` | Small set, complete view always needed |
+| `list_comment_reactions()` | `Vec<Reaction>` | Small set, complete view always needed |
+| `list_issue_activity_events()` | `Vec<IssueActivityEvent>` | Audit / state reconstruction needs all |
+| `list_issue_timeline()` | `Vec<TimelineEvent>` | Audit / state reconstruction needs all |
+
+**Auto-pagination implementation rule:**
+
+```text
+loop:
+  GET endpoint with per_page=100
+  collect items
+  if Link header contains rel="next": follow URL
+  else: break
+return collected items
+```
+
+Use `per_page=100` (GitHub's maximum) on the first request to minimise round trips.
+Follow the exact URL from the `Link: rel="next"` header for subsequent pages — do not
+reconstruct URLs manually, as GitHub may include additional state in the URL.
+
+## Consequences
+
+**Enables:**
+
+- Callers get a correct, complete result without pagination boilerplate.
+- Matches the contract expected by `cog_works` (issue #39).
+- API surface is simpler for the "complete list" pattern.
+
+**Forbids:**
+
+- Auto-paginating list operations cannot return early once started.
+- Memory is bounded only by total comment/event count (not a page limit).
+
+**Trade-offs accepted:**
+
+- A very large comment thread (thousands of comments) will load all into memory.
+  This is acceptable: such threads are extremely rare and the SDK is a library, not a
+  long-running service that accumulates data.
+- `list_issues()` retains `PagedResponse<Issue>` and is NOT changed to auto-paginate,
+  because repository issue counts routinely reach tens of thousands.
+
+## Alternatives considered
+
+### Option A: Always return `PagedResponse<T>`, let caller paginate
+
+**Why not**: Callers must implement pagination loops themselves. For the state-reconstruction
+use case, partial reads produce incorrect results (wrong state, stale lock). Code duplication
+across every caller.
+
+### Option B: Auto-paginate all list operations uniformly
+
+**Why not**: `list_issues()` on a large repository would fetch thousands of objects and take
+many seconds. Auto-pagination is appropriate where the collection is bounded, not for open-ended
+repository-level lists.
+
+### Option C: Add a separate `list_all_issue_comments()` alongside the existing paged version
+
+**Why not**: Adds API noise. The paged version currently returns only page 1 and has no utility
+in its current form. Replacing it with auto-pagination is a breaking change, but the method did
+not fulfil its contract anyway.
+
+## Implementation notes
+
+- The pagination loop must propagate any `ApiError` immediately; do not swallow errors mid-page.
+- Add `per_page=100` as a query parameter on the initial request.
+- For subsequent pages, use the URL from the `Link` header verbatim (call `self.get_url(&url)`
+  rather than `self.get(&path)`).
+- Existing `parse_link_header()` utility in `client/mod.rs` extracts the `next` URL; reuse it.
+
+## Examples
+
+```rust
+// Caller code – no pagination boilerplate needed
+let comments = client
+    .list_issue_comments("owner", "repo", 42)
+    .await?;
+
+// Find most recent state snapshot
+let snapshot = comments
+    .iter()
+    .rev()
+    .find(|c| c.body.starts_with("<!-- pipeline-state:"))
+    .map(|c| serde_json::from_str::<PipelineState>(&c.body[20..]));
+```
+
+## References
+
+- [GitHub issue #39](https://github.com/pvandervelde/github-bot-sdk/issues/39)
+- [GitHub REST API Link headers](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api)
+- [RFC 5988 – Web Linking](https://datatracker.ietf.org/doc/html/rfc5988)

--- a/docs/adr/ADR-003-sub-client-api-pattern.md
+++ b/docs/adr/ADR-003-sub-client-api-pattern.md
@@ -1,0 +1,152 @@
+# ADR-003: Domain Sub-Client Pattern for InstallationClient
+
+Status: Accepted
+Date: 2026-04-04
+Owners: github-bot-sdk team
+
+## Context
+
+The `InstallationClient` type is a flat collection of every GitHub API operation. At the
+time of this decision it contains 65 methods across 8 source files, and the upcoming
+issue-area expansion (ADR-002) would add ~20 more, reaching ~85 methods on a single type.
+
+User feedback (and the call pattern expected in issue #39) reveals that callers expect a
+grouped, domain-oriented API:
+
+```rust
+// What cog_works expected:
+sdk.issues().list_comments(owner, repo, id)
+
+// What actually existed:
+sdk.list_issue_comments(owner, repo, id)
+```
+
+Beyond discoverability, the flat layout has three concrete problems:
+
+1. **Naming tax**: Every method must carry its domain as a prefix to avoid ambiguity
+   (`list_issue_comments`, `list_pull_request_comments`) even though the prefix adds
+   no information when navigating from a domain-specific context.
+2. **Missing prefix inconsistency**: Several methods that *should* have domain prefixes
+   don't (e.g. `list_reviews`, `get_review`, `create_review` are PR-only but look generic).
+3. **No natural grouping for autocomplete**: Typing `client.` shows all 85+ methods with
+   no structure. Typing `client.issues().` shows only issue-domain methods.
+
+## Decision
+
+Introduce **immutable, zero-cost domain sub-clients** returned by factory methods on
+`InstallationClient`. Each sub-client groups one cohesive domain of GitHub API operations.
+
+Factory methods are synchronous, return by value, and require no API calls:
+
+```rust
+client.issues()        → IssuesClient
+client.pull_requests() → PullRequestsClient
+client.labels()        → LabelsClient
+client.milestones()    → MilestonesClient
+client.repositories()  → RepositoriesClient
+client.workflows()     → WorkflowsClient
+client.releases()      → ReleasesClient
+client.projects()      → ProjectsClient
+```
+
+**Flat methods within each sub-client (Option A)**: operations remain directly on
+the sub-client, not nested further. `client.issues().list_comments(...)` not
+`client.issues().comments().list(...)`. This keeps the API one layer deep for call sites
+and avoids the cognitive overhead of further nesting.
+
+**`owner`/`repo` stay on every method**: sub-clients are not bound to a specific repository.
+This preserves the ability to operate across multiple repositories from a single
+`InstallationClient`, which is essential for bots that process events from many repos.
+
+**Labels use a two-client split**:
+
+- `client.labels()` → `LabelsClient` for *repository-level label catalogue* (create, update,
+  delete, list, get a label definition).
+- `client.issues()` → label application methods (`add_labels`, `remove_label`,
+  `replace_labels`, `list_labels`) for attaching/detaching labels on specific issues.
+- `client.pull_requests()` → same label application methods for PRs.
+
+This reflects GitHub's own API structure: label definitions live at `/repos/{owner}/{repo}/labels`,
+while label application lives at `/repos/{owner}/{repo}/issues/{number}/labels`.
+
+**Method naming within sub-clients**: redundant domain prefixes are dropped because the
+sub-client itself carries the domain context.
+
+| Old flat name | New sub-client + method |
+|---|---|
+| `client.list_issues(...)` | `client.issues().list(...)` |
+| `client.list_issue_comments(...)` | `client.issues().list_comments(...)` |
+| `client.create_issue_comment(...)` | `client.issues().create_comment(...)` |
+| `client.list_reviews(...)` | `client.pull_requests().list_reviews(...)` |
+| `client.list_labels(...)` | `client.labels().list(...)` |
+| `client.create_label(...)` | `client.labels().create(...)` |
+| `client.add_labels_to_issue(...)` | `client.issues().add_labels(...)` |
+| `client.add_labels_to_pull_request(...)` | `client.pull_requests().add_labels(...)` |
+| `client.list_releases(...)` | `client.releases().list(...)` |
+| `client.get_workflow(...)` | `client.workflows().get(...)` |
+
+## Consequences
+
+**Enables:**
+
+- Discoverability: typing `client.issues().` shows only issue-domain operations.
+- Concise call sites: no repetitive domain prefixes on every method name.
+- Consistent naming: `list`, `get`, `create`, `update`, `delete` at the sub-client level.
+- `reviews` are unambiguously PR-only when accessed via `client.pull_requests().list_reviews()`.
+- Missing PR comment methods (`update_comment`, `delete_comment`) added as part of this change,
+  completing the CRUD symmetry with issue comments.
+
+**Constraints:**
+
+- `InstallationClient` retains its generic HTTP helpers (`get`, `post`, `patch`, `put`,
+  `delete`) so sub-clients can delegate to it.
+- Sub-clients MUST NOT hold state beyond what is needed to delegate to the parent.
+- Sub-clients MUST be cheap to construct (no API calls, no heap allocation beyond an
+  `Arc` increment or reference copy).
+- Sub-clients MUST be `Clone` and `Debug`.
+- The old flat methods on `InstallationClient` are REMOVED (not deprecated alongside the
+  new API) — this is a breaking change but the SDK is pre-1.0.
+
+**Trade-offs accepted:**
+
+- One extra `.method()` call at the call site: `client.issues()` wrapping.
+- Sub-clients cannot be stored without cloning the `Arc<GitHubClient>` or borrowing
+  `InstallationClient`; the interface designer chooses the ownership model.
+
+## Alternatives considered
+
+### Option B: Two levels of nesting for issues (e.g. `client.issues().comments().list()`)
+
+**Why not**: Adds call-site verbosity without significant discoverability benefit over
+Option A. The `client.issues()` grouping already scopes operations to the issue domain;
+further nesting produces longer chains and more types with no practical payoff.
+
+### Option C: Keep flat, only fix naming consistency
+
+**Why not**: Solves Inconsistency 2 (prefixes) but not the 85-method discoverability
+problem. Callers still see all domains mixed together in autocomplete.
+
+### Option D: Keep flat, add doc-comments with `# See Also` groups
+
+**Why not**: Documentation cannot replace API organisation. Autocomplete remains noisy.
+This is a non-solution masquerading as one.
+
+### Option E: Repository-bound sub-clients (bind `owner`/`repo` at construction)
+
+**Why not**: Unnecessary rigidity. Bots frequently process events from multiple repositories
+within a single installation. Having to construct a new sub-client per repo adds ceremony
+for a marginal naming benefit.
+
+## Implementation notes
+
+- Source file organisation does NOT change: `issue.rs`, `pull_request.rs`, etc. each define
+  their own sub-client struct and `impl` block. `InstallationClient` factory methods are
+  added to `installation.rs` (or a thin `mod.rs` delegating import).
+- Tests use the new method names from day one; old tests are updated, not kept alongside.
+- The `pub use` re-exports in `client/mod.rs` add the new sub-client types.
+
+## References
+
+- [GitHub issue #39](https://github.com/pvandervelde/github-bot-sdk/issues/39) — `list_comments` gap and expected API shape
+- [ADR-002](ADR-002-auto-pagination-strategy.md) — auto-pagination strategy
+- API consistency review (2026-04-04 session)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,10 @@ This folder contains ADRs documenting important architectural decisions.
 Naming: ADR-<number>-short-title.md
 
 Do not add example ADRs automatically. Use the ADR template to create new ADRs.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](ADR-001-hexagonal-architecture.md) | Hexagonal Architecture for Provider Abstraction | Accepted |
+| [ADR-002](ADR-002-auto-pagination-strategy.md) | Auto-Pagination Strategy for Issue Comment Listing | Accepted |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -177,7 +177,8 @@ Security architecture, threat model, and mitigations
 
 - [installation-client.md](interfaces/installation-client.md) - Client foundation
 - [repository-operations.md](interfaces/repository-operations.md) - Repository API
-- [issue-operations.md](interfaces/issue-operations.md) - Issue and comment API
+- [issue-operations.md](interfaces/issue-operations.md) - Issue, comment, assignee, label, lock, milestone, timeline API
+- [reactions.md](interfaces/reactions.md) - Emoji reactions on issues and comments
 - [pull-request-operations.md](interfaces/pull-request-operations.md) - Pull request API
 - [project-operations.md](interfaces/project-operations.md) - Project management API
 - [pagination.md](interfaces/pagination.md) - Pagination support

--- a/docs/specs/assertions.md
+++ b/docs/specs/assertions.md
@@ -563,3 +563,280 @@ This document defines testable behavioral assertions for the GitHub Bot SDK. The
 - Performance targets met
 - Single API call per operation
 - No redundant requests
+
+---
+
+## Issue Extended Operations Assertions
+
+### Assertion 38: list_issue_comments Returns All Pages
+
+**Given**: An issue with 150 comments (two pages of 100 + 50)
+**When**: `list_issue_comments(owner, repo, issue_number)` is called
+**Then**: Returns `Ok(Vec<Comment>)` with all 150 comments
+**And**: Comments are in ascending `created_at` order (oldest first)
+**And**: Exactly two HTTP requests were made (one per page)
+
+**Test Criteria**:
+
+- Result length is 150
+- Timestamps are non-decreasing across the full result
+- First request uses `per_page=100`; second follows `Link: rel="next"` URL verbatim
+- No third HTTP request is made after the last page
+
+### Assertion 39: list_issue_comments on Non-Existent Issue
+
+**Given**: An issue number that does not exist in the repository
+**When**: `list_issue_comments(owner, repo, 9999999)` is called
+**Then**: Returns `Err(ApiError::NotFound)`
+**And**: Error propagates immediately without further page requests
+
+**Test Criteria**:
+
+- Error type is `ApiError::NotFound`
+- Exactly one HTTP request was made
+- No partial results returned
+
+### Assertion 40: list_issue_comments on Empty Issue
+
+**Given**: An issue with zero comments
+**When**: `list_issue_comments(owner, repo, issue_number)` is called
+**Then**: Returns `Ok(vec![])`
+
+**Test Criteria**:
+
+- Result is an empty vector, not an error
+- Exactly one HTTP request was made
+
+### Assertion 41: add_assignees_to_issue with Eligible Users
+
+**Given**: Users "alice" and "bob" are collaborators in the repository
+**When**: `add_assignees_to_issue(owner, repo, 1, vec!["alice", "bob"])` is called
+**Then**: Returns `Ok(Issue)` with both users in the `assignees` field
+**And**: A POST to `/repos/{owner}/{repo}/issues/1/assignees` was made
+
+**Test Criteria**:
+
+- Updated issue contains both assignees
+- Body sent was `{ "assignees": ["alice", "bob"] }`
+
+### Assertion 42: add_assignees_to_issue with Ineligible User (Silent Ignore)
+
+**Given**: User "external-user" is not a collaborator
+**When**: `add_assignees_to_issue(owner, repo, 1, vec!["external-user"])` is called
+**Then**: Returns `Ok(Issue)` with no change to the assignee list
+**And**: GitHub silently ignores the ineligible user (no 422)
+
+**Test Criteria**:
+
+- Returns `Ok(Issue)` (not an error)
+- Assignee list unchanged in returned issue
+
+### Assertion 43: remove_assignees_from_issue
+
+**Given**: Issue 1 is currently assigned to "alice"
+**When**: `remove_assignees_from_issue(owner, repo, 1, vec!["alice"])` is called
+**Then**: Returns `Ok(Issue)` with empty assignees
+**And**: A DELETE to `/repos/{owner}/{repo}/issues/1/assignees` was made with the body
+
+**Test Criteria**:
+
+- Returned issue has empty assignees list
+- HTTP method is DELETE (not POST); body contains `{ "assignees": ["alice"] }`
+
+### Assertion 44: lock_issue with Reason
+
+**Given**: An open, unlocked issue
+**When**: `lock_issue(owner, repo, 42, Some(LockReason::TooHeated))` is called
+**Then**: Returns `Ok(())`
+**And**: A PUT to `/repos/{owner}/{repo}/issues/42/lock` was made
+**And**: Request body contained `{ "lock_reason": "too heated" }`
+
+**Test Criteria**:
+
+- HTTP status 204 treated as success
+- `lock_reason` serialised as `"too heated"` (kebab-case)
+
+### Assertion 45: lock_issue without Reason
+
+**Given**: An open, unlocked issue
+**When**: `lock_issue(owner, repo, 42, None)` is called
+**Then**: Returns `Ok(())`
+**And**: Request body is empty (or omits the `lock_reason` field)
+
+**Test Criteria**:
+
+- No `lock_reason` key in JSON body when reason is `None`
+
+### Assertion 46: unlock_issue
+
+**Given**: A locked issue
+**When**: `unlock_issue(owner, repo, 42)` is called
+**Then**: Returns `Ok(())`
+**And**: A DELETE to `/repos/{owner}/{repo}/issues/42/lock` was made
+
+**Test Criteria**:
+
+- HTTP status 204 treated as success
+- No body required
+
+### Assertion 47: replace_labels_on_issue Atomically Replaces All Labels
+
+**Given**: Issue 3 currently has labels ["bug", "help-wanted"]
+**When**: `replace_labels_on_issue(owner, repo, 3, vec!["enhancement".into()])` is called
+**Then**: Returns `Ok(Vec<Label>)` containing only "enhancement"
+**And**: "bug" and "help-wanted" are no longer on the issue
+
+**Test Criteria**:
+
+- Result contains exactly one label: "enhancement"
+- A PUT (not POST) request was made
+- Body was `{ "labels": ["enhancement"] }`
+
+### Assertion 48: replace_labels_on_issue with Empty List Clears All Labels
+
+**Given**: Issue 3 with existing labels
+**When**: `replace_labels_on_issue(owner, repo, 3, vec![])` is called
+**Then**: Returns `Ok(vec![])`
+**And**: All labels removed
+
+**Test Criteria**:
+
+- Body sent was `{ "labels": [] }`
+- Result is empty vector
+
+### Assertion 49: create_issue_reaction Returns Existing on Duplicate
+
+**Given**: The authenticated bot has already reacted with 👀 on issue 1
+**When**: `create_issue_reaction(owner, repo, 1, ReactionContent::Eyes)` is called again
+**Then**: Returns `Ok(Reaction)` (not an error)
+**And**: GitHub returns HTTP 200 (not 201) for the duplicate
+
+**Test Criteria**:
+
+- Both HTTP 200 and HTTP 201 from GitHub result in `Ok(Reaction)`
+- The returned `Reaction` has the same `id` as the original
+
+### Assertion 50: create_issue_reaction on Non-Existent Issue
+
+**Given**: Issue number that does not exist
+**When**: `create_issue_reaction(owner, repo, 9999, ReactionContent::PlusOne)` is called
+**Then**: Returns `Err(ApiError::NotFound)`
+
+**Test Criteria**:
+
+- Error type is `ApiError::NotFound`
+
+### Assertion 51: delete_issue_reaction Succeeds
+
+**Given**: A known reaction ID 42 on issue 1
+**When**: `delete_issue_reaction(owner, repo, 1, 42)` is called
+**Then**: Returns `Ok(())`
+**And**: A DELETE to `/repos/{owner}/{repo}/issues/1/reactions/42` was made
+
+**Test Criteria**:
+
+- HTTP 204 treated as success
+
+### Assertion 52: list_issue_reactions Auto-Paginates
+
+**Given**: Issue with 150 reactions across two pages
+**When**: `list_issue_reactions(owner, repo, issue_number)` is called
+**Then**: Returns all 150 reactions
+**And**: Two HTTP requests were made following `Link: rel="next"`
+
+**Test Criteria**:
+
+- Result length is 150
+- Two requests made
+
+### Assertion 53: Comment reactions follow identical contract to issue reactions
+
+All assertions from 49–52 apply symmetrically to:
+
+- `create_comment_reaction()`
+- `delete_comment_reaction()`
+- `list_comment_reactions()`
+
+with the endpoint swapped to `/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions`.
+
+**Test Criteria**:
+
+- Identical success and error behaviour
+- Correct endpoint used (`issues/comments/{id}` not `issues/{number}`)
+
+### Assertion 54: create_milestone Returns Created Milestone
+
+**Given**: Repository with `issues:write` permission
+**When**: `create_milestone(owner, repo, CreateMilestoneRequest { title: "v2.0", .. })` is called
+**Then**: Returns `Ok(Milestone)` with a GitHub-assigned `number`
+**And**: Milestone `title` matches the request
+
+**Test Criteria**:
+
+- HTTP 201 treated as success
+- `number` is non-zero
+
+### Assertion 55: create_milestone with Duplicate Title Returns InvalidRequest
+
+**Given**: Milestone "v2.0" already exists in the repository
+**When**: `create_milestone(owner, repo, ...)` is called with title "v2.0"
+**Then**: Returns `Err(ApiError::InvalidRequest { .. })`
+
+**Test Criteria**:
+
+- GitHub returns HTTP 422; maps to `ApiError::InvalidRequest`
+
+### Assertion 56: delete_milestone Succeeds
+
+**Given**: Milestone number 3 exists
+**When**: `delete_milestone(owner, repo, 3)` is called
+**Then**: Returns `Ok(())`
+**And**: HTTP 204 was returned
+
+**Test Criteria**:
+
+- Milestone is removed
+- Associated issues retain their milestone field until manually cleared
+
+### Assertion 57: list_issue_activity_events Returns All Events
+
+**Given**: Issue 5 with 120 recorded activity events (two pages)
+**When**: `list_issue_activity_events(owner, repo, 5)` is called
+**Then**: Returns all 120 events in ascending chronological order
+**And**: Two HTTP requests were made
+
+**Test Criteria**:
+
+- Result length is 120
+- Events sorted oldest-first
+- Second request follows `Link: rel="next"` verbatim
+
+### Assertion 58: list_issue_timeline Returns Mixed Event Types Without Error
+
+**Given**: Issue with a mix of commented, labeled, closed, and referenced events
+**When**: `list_issue_timeline(owner, repo, issue_number)` is called
+**Then**: Returns `Ok(Vec<TimelineEvent>)` with all items
+**And**: Each item deserializes to the correct `TimelineEvent` variant
+**And**: Unknown event types deserialize to `TimelineEvent::Unknown` without panicking
+
+**Test Criteria**:
+
+- No deserialization errors
+- Commented variant contains body text
+- Labeled variant contains label name
+- Unknown variant does not cause an `Err`
+
+### Assertion 59: IssueCommentEvent Webhook Deserializes Correctly
+
+**Given**: Raw `issue_comment` webhook payload with `action: "created"`
+**When**: `serde_json::from_value::<IssueCommentEvent>(payload)` is called
+**Then**: Returns `Ok(IssueCommentEvent)` with correct fields
+**And**: `action` is `IssueCommentAction::Created`
+**And**: `issue` contains the parent issue metadata
+**And**: `comment` contains the new comment body
+
+**Test Criteria**:
+
+- All three action variants (`created`, `edited`, `deleted`) deserialize correctly
+- `issue.number` matches the issue number in the payload
+- `comment.body` contains the comment text

--- a/docs/specs/constraints.md
+++ b/docs/specs/constraints.md
@@ -420,26 +420,26 @@ All public types/methods MUST have complete rustdoc with examples, parameters, e
 
 ### Auto-Pagination
 
-- `list_issue_comments()` MUST auto-paginate using `per_page=100` and follow all `Link: rel="next"` headers (ADR-002)
+- `issues().list_comments()` MUST auto-paginate using `per_page=100` and follow all `Link: rel="next"` headers (ADR-002)
 - All other auto-paginating list methods (reactions, activity events, timeline, milestones, available assignees) MUST follow the same loop pattern
-- Auto-pagination MUST propagate any `ApiError` immediately on a page fetch failure  do not return a partial list
-- Subsequent page URLs MUST be used verbatim from the `Link` header  do not reconstruct URLs manually
+- Auto-pagination MUST propagate any `ApiError` immediately on a page fetch failure — do not return a partial list
+- Subsequent page URLs MUST be used verbatim from the `Link` header — do not reconstruct URLs manually
 
 ### Reactions
 
-- `create_issue_reaction()` and `create_comment_reaction()` MUST treat both HTTP 200 and HTTP 201 responses as `Ok(Reaction)`
+- `issues().create_reaction()` and `issues().create_comment_reaction()` MUST treat both HTTP 200 and HTTP 201 responses as `Ok(Reaction)`
 - `ReactionContent::PlusOne` and `ReactionContent::MinusOne` MUST serialize to `"+1"` and `"-1"` respectively (GitHub API names)
 
 ### Issue Locking
 
-- `lock_issue()` MUST use HTTP PUT to `/repos/{owner}/{repo}/issues/{number}/lock`
-- `unlock_issue()` MUST use HTTP DELETE to the same path
+- `issues().lock()` MUST use HTTP PUT to `/repos/{owner}/{repo}/issues/{number}/lock`
+- `issues().unlock()` MUST use HTTP DELETE to the same path
 - Both methods treat HTTP 204 as success
 - `LockReason` MUST serialize with kebab-case (`off-topic`, `too-heated`, `resolved`, `spam`)
 
 ### Assignees
 
-- `remove_assignees_from_issue()` MUST use HTTP DELETE with a JSON body containing `{ "assignees": [...] }`  GitHub requires a body on this DELETE
+- `issues().remove_assignees()` MUST use HTTP DELETE with a JSON body containing `{ "assignees": [...] }` — GitHub requires a body on this DELETE
 - Implementations MUST NOT validate assignee eligibility client-side; GitHub's silent ignore is the authoritative behaviour
 
 ### Timeline Deserialization
@@ -456,8 +456,8 @@ All public types/methods MUST have complete rustdoc with examples, parameters, e
 
 ### Milestone CRUD
 
-- Milestone CRUD methods (`get_milestone`, `list_milestones`, `create_milestone`, `update_milestone`, `delete_milestone`) live in `src/client/issue.rs` alongside the existing `Milestone` type and `set_issue_milestone()`
-- There is NO separate `milestone.rs` file  the note in `additional-operations.md` predates the decision to consolidate in `issue.rs`
+- `milestones().get()`, `milestones().list()`, `milestones().create()`, `milestones().update()`, `milestones().delete()` live in `src/client/issue.rs` alongside the existing `Milestone` type and `issues().set_milestone()`
+- There is NO separate `milestone.rs` file — the note in `additional-operations.md` predates the decision to consolidate in `issue.rs`
 
 ---
 
@@ -524,6 +524,8 @@ All public types/methods MUST have complete rustdoc with examples, parameters, e
 | `issues().list_available_assignees` | Auto-paginated | Bounded collaborator set |
 | `issues().list_activity_events` | Auto-paginated | Bounded per issue |
 | `issues().list_timeline` | Auto-paginated | Must be complete for audit |
+| `issues().list_labels` | Auto-paginated | Bounded per issue |
+| `pull_requests().list_reviews` | Auto-paginated | Bounded per PR |
 | `repositories().list_branches` | Auto-paginated | Bounded per repo |
 | `repositories().list_tags` | Auto-paginated | Bounded per repo |
 | `issues().list` | Manual (`PagedResponse<T>`) | Caller may stop early; unbounded in large repos |

--- a/docs/specs/constraints.md
+++ b/docs/specs/constraints.md
@@ -413,3 +413,125 @@ Error messages MUST include context but NEVER include tokens, keys, or sensitive
 ### Documentation
 
 All public types/methods MUST have complete rustdoc with examples, parameters, errors, and links
+
+---
+
+## Issue Extended Operations Constraints
+
+### Auto-Pagination
+
+- `list_issue_comments()` MUST auto-paginate using `per_page=100` and follow all `Link: rel="next"` headers (ADR-002)
+- All other auto-paginating list methods (reactions, activity events, timeline, milestones, available assignees) MUST follow the same loop pattern
+- Auto-pagination MUST propagate any `ApiError` immediately on a page fetch failure  do not return a partial list
+- Subsequent page URLs MUST be used verbatim from the `Link` header  do not reconstruct URLs manually
+
+### Reactions
+
+- `create_issue_reaction()` and `create_comment_reaction()` MUST treat both HTTP 200 and HTTP 201 responses as `Ok(Reaction)`
+- `ReactionContent::PlusOne` and `ReactionContent::MinusOne` MUST serialize to `"+1"` and `"-1"` respectively (GitHub API names)
+
+### Issue Locking
+
+- `lock_issue()` MUST use HTTP PUT to `/repos/{owner}/{repo}/issues/{number}/lock`
+- `unlock_issue()` MUST use HTTP DELETE to the same path
+- Both methods treat HTTP 204 as success
+- `LockReason` MUST serialize with kebab-case (`off-topic`, `too-heated`, `resolved`, `spam`)
+
+### Assignees
+
+- `remove_assignees_from_issue()` MUST use HTTP DELETE with a JSON body containing `{ "assignees": [...] }`  GitHub requires a body on this DELETE
+- Implementations MUST NOT validate assignee eligibility client-side; GitHub's silent ignore is the authoritative behaviour
+
+### Timeline Deserialization
+
+- `TimelineEvent` MUST deserialize unknown event kinds to a catch-all variant without returning `Err`
+- The implementation MUST NOT `panic!` on unknown timeline event types
+- The catch-all variant MAY discard fields from unknown types (no requirement to preserve raw JSON unless specified later)
+
+### IssueCommentEvent
+
+- `IssueCommentEvent` lives in `src/events/github_events.rs` alongside `IssueEvent` and `PullRequestEvent`
+- `IssueCommentEvent::comment` MUST use the same `Comment` type from `src/client/issue.rs`
+- `IssueCommentEvent::issue` MUST use the same `Issue` type from `src/client/issue.rs`
+
+### Milestone CRUD
+
+- Milestone CRUD methods (`get_milestone`, `list_milestones`, `create_milestone`, `update_milestone`, `delete_milestone`) live in `src/client/issue.rs` alongside the existing `Milestone` type and `set_issue_milestone()`
+- There is NO separate `milestone.rs` file  the note in `additional-operations.md` predates the decision to consolidate in `issue.rs`
+
+---
+
+## Sub-Client API Constraints (ADR-003)
+
+### Sub-Client Construction
+
+- All factory methods on `InstallationClient` MUST be infallible (`&self -> SubClient`, no `Result`)
+- All factory methods MUST be O(1) and make NO API calls during construction
+- Sub-clients MUST be `Clone` and `Debug`
+- Sub-clients MUST NOT hold any mutable state
+
+### Sub-Client Delegation
+
+- All HTTP operations in sub-clients MUST delegate to `InstallationClient`'s internal helpers
+- Sub-clients MUST NOT create their own HTTP clients or manage their own tokens
+- Sub-clients hold a clone of (or a reference to) the parent `InstallationClient` so that
+  token caching and rate limiting remain centralised
+
+### Sub-Client File Placement
+
+| Sub-Client | Source file |
+|---|---|
+| `IssuesClient` | `src/client/issue.rs` |
+| `LabelsClient` | `src/client/issue.rs` |
+| `MilestonesClient` | `src/client/issue.rs` |
+| `PullRequestsClient` | `src/client/pull_request.rs` |
+| `RepositoriesClient` | `src/client/repository.rs` (+ commit.rs for commit methods) |
+| `WorkflowsClient` | `src/client/workflow.rs` |
+| `ReleasesClient` | `src/client/release.rs` |
+| `ProjectsClient` | `src/client/project.rs` |
+
+### Label Responsibility Split
+
+- **Repo-level label catalogue** (create/update/delete label definitions): `LabelsClient`
+- **Applying labels to an issue**: `IssuesClient::add_labels`, `IssuesClient::remove_label`, `IssuesClient::replace_labels`
+- **Applying labels to a PR**: `PullRequestsClient::add_labels`, `PullRequestsClient::remove_label`
+
+### Method Naming on Sub-Clients
+
+- Methods on sub-clients MUST NOT repeat the domain noun in their name because the
+  sub-client already provides domain context
+  - CORRECT: `client.issues().list(...)` / `client.labels().create(...)`
+  - WRONG: `client.issues().list_issues(...)` / `client.labels().create_label(...)`
+- Exception: compound methods where the noun disambiguates the sub-resource are allowed
+  - `client.issues().list_comments(...)`, `client.issues().list_reactions(...)`,
+    `client.pull_requests().list_reviews(...)` — all acceptable because the noun names
+    the resource, not the domain
+
+### Review Method Naming on PullRequestsClient
+
+- Review methods MUST retain the `_review` / `_reviews` suffix to avoid ambiguity
+  with `list_comments` and other comment methods
+  - `list_reviews`, `get_review`, `create_review`, `update_review`, `dismiss_review`
+
+### Pagination Policy (ADR-002)
+
+| Operation | Strategy | Rationale |
+|---|---|---|
+| `issues().list_comments` | Auto-paginated | Must be complete for state reconstruction |
+| `labels().list` | Auto-paginated | Bounded catalogue set |
+| `milestones().list` | Auto-paginated | Bounded set per repo |
+| `issues().list_reactions` / `list_comment_reactions` | Auto-paginated | Bounded per resource |
+| `issues().list_available_assignees` | Auto-paginated | Bounded collaborator set |
+| `issues().list_activity_events` | Auto-paginated | Bounded per issue |
+| `issues().list_timeline` | Auto-paginated | Must be complete for audit |
+| `repositories().list_branches` | Auto-paginated | Bounded per repo |
+| `repositories().list_tags` | Auto-paginated | Bounded per repo |
+| `issues().list` | Manual (`PagedResponse<T>`) | Caller may stop early; unbounded in large repos |
+| `pull_requests().list` | Manual | Unbounded |
+| `repositories().list_commits` | Manual | Arbitrarily large history |
+
+### Backward Compatibility
+
+- The old flat `InstallationClient` methods (`list_issues`, `get_issue_comment`, etc.) MUST be removed
+- There is NO compatibility shim; this is a clean API replacement before the 1.0 release
+- The change is tracked in CHANGELOG.md as a breaking change

--- a/docs/specs/edge-cases.md
+++ b/docs/specs/edge-cases.md
@@ -568,3 +568,154 @@ Each edge case should have:
 - **P1 (High)**: Rate limiting, token refresh, webhook validation
 - **P2 (Medium)**: Pagination, concurrency, configuration
 - **P3 (Low)**: Rare edge cases, future compatibility
+
+---
+
+## Issue Extended Operations Edge Cases
+
+### Edge Case 17: Auto-Pagination with Token Refresh Mid-List
+
+**Scenario**: Installation token expires after the first page of `list_issue_comments()` is fetched
+but before the second page request.
+
+**Expected Behavior**:
+
+- Token refresh logic kicks in silently before the second page request
+- The second page request succeeds with the fresh token
+- Caller receives the complete comment list as if nothing happened
+
+**Handling Strategy**:
+
+- Check token expiry before each page request in the pagination loop (same as for single requests)
+- Do not propagate a 401 to the caller; treat it as a refresh trigger and retry the page once
+- Log the token refresh at DEBUG level
+
+**Test Cases**:
+
+- Token expires exactly between page 1 and page 2 requests
+- Token refresh itself fails (network error): propagate `ApiError::AuthenticationFailed`
+
+---
+
+### Edge Case 18: Reaction Creates Duplicate for Different User
+
+**Scenario**: User A has reacted with . The bot (a different user) also calls
+`create_issue_reaction` with `ReactionContent::PlusOne`.
+
+**Expected Behavior**:
+
+- GitHub creates a new, separate reaction for the bot
+- Returns HTTP 201 with the bot's reaction
+- Caller receives `Ok(Reaction)` for the bot's new reaction
+
+**Handling Strategy**:
+
+- This is the normal, happy-path case when users and the bot react independently
+- The duplicate-reaction idempotency (HTTP 200) only applies to the same authenticated user
+- No special handling needed beyond treating both 200 and 201 as `Ok(Reaction)`
+
+---
+
+### Edge Case 19: Issue Locked  Comment Creation Rejected
+
+**Scenario**: Bot attempts `create_issue_comment()` on an issue that has been locked and the bot
+does not have collaborator access.
+
+**Impact**:
+
+- GitHub returns HTTP 403
+- Bot cannot post the comment
+
+**Expected Behavior**:
+
+- `create_issue_comment()` returns `Err(ApiError::AuthorizationFailed)`
+- Error message does not expose the lock reason (GitHub's response handles this)
+- Callers should check issue lock status before attempting to comment if this is a concern
+
+**Handling Strategy**:
+
+- Map HTTP 403 to `ApiError::AuthorizationFailed` (existing pattern)
+- Callers can inspect `issue.locked` field returned by `get_issue()` before commenting
+
+---
+
+### Edge Case 20: Timeline Unknown Event Types
+
+**Scenario**: GitHub adds a new timeline event type that the SDK does not yet recognise (e.g.,
+a new `"sub_issue_added"` event kind introduced in a future GitHub API update).
+
+**Expected Behavior**:
+
+- The new event type deserializes to `TimelineEvent::Unknown` without error
+- The caller's result vector contains the `Unknown` variant for that item
+- No panic or deserialization failure occurs
+- SDK continues functioning for all known event types
+
+**Handling Strategy**:
+
+- The `TimelineEvent` enum uses `#[serde(other)]` or a custom deserializer for the catch-all
+- Callers can `match` on variants and use a wildcard `_` arm for `Unknown`
+- SDK does not log a warning for unknown types by default (too noisy); callers decide
+
+---
+
+### Edge Case 21: list_issue_activity_events with No Events
+
+**Scenario**: A freshly created issue has no activity events yet (only a "created" record, which
+GitHub sometimes omits from the events list on very new issues).
+
+**Expected Behavior**:
+
+- Returns `Ok(vec![])` (empty list, not an error)
+
+---
+
+### Edge Case 22: Assignment of Bot to Issue (Self-Assignment)
+
+**Scenario**: Bot assigns itself using `add_assignees_to_issue()` with its own login.
+
+**Expected Behavior**:
+
+- GitHub Apps can be assigned if the installation has collaborator access
+- If the app does not have collaborator access, GitHub silently ignores the login
+- Returns `Ok(Issue)` in both cases (GitHub never 422s for ineligible assignees)
+
+**Handling Strategy**:
+
+- No special handling needed; document this behaviour in the method's rustdoc
+- Callers can use `list_available_assignees()` to check eligibility before attempting
+
+---
+
+### Edge Case 23: Milestone Due Date in the Past
+
+**Scenario**: `create_milestone()` or `update_milestone()` is called with a `due_on` timestamp
+that is already in the past.
+
+**Expected Behavior**:
+
+- GitHub accepts past due dates without error
+- Returns `Ok(Milestone)` with the past `due_on` value
+- The milestone displays as "overdue" on GitHub's UI, but this is not an API error
+
+**Handling Strategy**:
+
+- No client-side validation of `due_on` in the past (GitHub permits it)
+- Document in rustdoc that GitHub accepts past dates
+
+---
+
+### Edge Case 24: Delete Milestone with Associated Open Issues
+
+**Scenario**: `delete_milestone()` is called on a milestone that still has open issues.
+
+**Expected Behavior**:
+
+- GitHub deletes the milestone without error
+- The associated issues lose their milestone reference (set to null by GitHub)
+- Returns `Ok(())`
+
+**Handling Strategy**:
+
+- No special handling; document this side-effect in the method's rustdoc
+- Callers who need to preserve milestone state must migrate issues first

--- a/docs/specs/interfaces/README.md
+++ b/docs/specs/interfaces/README.md
@@ -1,83 +1,138 @@
 # GitHub Bot SDK Interface Specifications
 
-This directory contains detailed interface specifications for the GitHub Bot SDK installation-level client operations. Each specification defines type signatures, function contracts, error conditions, and usage examples.
+This directory contains detailed interface specifications for the GitHub Bot SDK
+installation-level client operations. Each specification defines type signatures,
+function contracts, error conditions, and usage examples.
 
-## Overview
+## Architecture: Domain Sub-Clients (ADR-003)
 
-The installation-level client provides authenticated access to GitHub API operations scoped to a specific app installation. All operations use installation tokens (not JWTs) and respect GitHub's rate limiting and permissions.
+All GitHub API operations are grouped into **domain sub-clients** accessed via factory
+methods on `InstallationClient`. Each sub-client is cheap to construct (no API call,
+at most an `Arc` increment) and contains flat methods (no further nesting).
+
+```rust
+// All operations accessed through dedicated sub-clients
+client.issues().list("owner", "repo", state, page).await?;
+client.pull_requests().merge("owner", "repo", 42, None).await?;
+client.labels().create("owner", "repo", req).await?;
+client.milestones().list("owner", "repo", None).await?;
+client.repositories().get_branch("owner", "repo", "main").await?;
+client.workflows().trigger("owner", "repo", "ci.yml", req).await?;
+client.releases().get_latest("owner", "repo").await?;
+client.projects().list_for_issue("owner", "repo", 42).await?;
+```
 
 ## Interface Documents
 
 ### Core Client
 
-- **[installation-client.md](./installation-client.md)** - InstallationClient foundation
-  - Client struct definition
-  - Factory methods
+- **[installation-client.md](./installation-client.md)** — `InstallationClient` foundation
+  - Client struct definition and thread-safety guarantees
   - Generic request helpers (GET, POST, PUT, DELETE, PATCH)
+  - **Domain sub-client factory methods** (`issues()`, `pull_requests()`, `labels()`, etc.)
   - Token exchange integration
 
-### Repository Operations
+### Issue Domain
 
-- **[repository-operations.md](./repository-operations.md)** - Repository and branch management
-  - Repository information retrieval
-  - Branch operations (list, get, create, delete)
-  - Git reference management (tags, branches)
-  - Repository metadata updates
+- **[issue-operations.md](./issue-operations.md)** — `IssuesClient`
+  - Issue CRUD (`list`, `get`, `create`, `update`)
+  - Comments (`list_comments`, `get_comment`, `create_comment`, `update_comment`, `delete_comment`)
+  - Label application (`list_labels`, `add_labels`, `remove_label`, `replace_labels`)
+  - Reactions on issues and comments (6 methods)
+  - Assignees (`list_available_assignees`, `add_assignees`, `remove_assignees`)
+  - Lock / unlock
+  - Timeline and activity events (`list_timeline`, `list_activity_events`)
+  - Milestone assignment (`set_milestone`)
 
-### Issue and PR Operations
+- **[labels-client.md](./labels-client.md)** — `LabelsClient`
+  - Repository-level label catalogue (`list`, `get`, `create`, `update`, `delete`)
+  - *Applying* labels to issues: use `IssuesClient`; to PRs: use `PullRequestsClient`
 
-- **[issue-operations.md](./issue-operations.md)** - GitHub issue management
-  - Issue CRUD operations
-  - Issue comments
-  - Label management (create, update, delete)
-  - Issue state transitions
+- **[milestones-client.md](./milestones-client.md)** — `MilestonesClient`
+  - Milestone lifecycle (`list`, `get`, `create`, `update`, `delete`)
+  - *Assigning* milestones to issues/PRs: use `IssuesClient::set_milestone` / `PullRequestsClient::set_milestone`
 
-- **[pull-request-operations.md](./pull-request-operations.md)** - Pull request operations
-  - PR CRUD operations
-  - Review management
-  - PR comments and discussions
-  - Merge operations
+### Pull Request Domain
 
-### Cross-Domain Operations
+- **[pull-request-operations.md](./pull-request-operations.md)** — `PullRequestsClient`
+  - PR CRUD (`list`, `get`, `create`, `update`, `merge`)
+  - Reviews (`list_reviews`, `get_review`, `create_review`, `update_review`, `dismiss_review`)
+  - Comments (`list_comments`, `create_comment`, `update_comment`, `delete_comment`)
+  - Label application (`add_labels`, `remove_label`)
+  - Milestone assignment (`set_milestone`)
 
-- **[project-operations.md](./project-operations.md)** - GitHub Projects V2 management
-  - Project listing and retrieval
-  - Project item management
-  - Owner-scoped operations (user/organization)
+### Repository Domain
 
-- **[additional-operations.md](./additional-operations.md)** - Milestone, Workflow, and Release operations
-  - Milestone CRUD and associations
-  - GitHub Actions workflow triggers
-  - Release and asset management
+- **[repository-operations.md](./repository-operations.md)** — `RepositoriesClient`
+  - Repository metadata (`get`)
+  - Branches (`list_branches`, `get_branch`, `create_branch`)
+  - Git references (`get_ref`, `create_ref`, `update_ref`, `delete_ref`)
+  - Tags (`list_tags`, `create_tag`)
+  - Commits (`get_commit`, `list_commits`, `compare`)
+
+### Additional Domains
+
+- **[project-operations.md](./project-operations.md)** — `ProjectsClient`
+  - GitHub Projects V2 (`list_for_org`, `list_for_user`, `get`, `add_item`, `remove_item`, `list_for_issue`)
+
+- **[additional-operations.md](./additional-operations.md)** — `WorkflowsClient` and `ReleasesClient`
+  - Workflows: `list`, `get`, `trigger`, `list_runs`, `get_run`, `cancel_run`, `rerun_run`
+  - Releases: `list`, `get`, `get_latest`, `get_by_tag`, `create`, `update`, `delete`
+
+- **[reactions.md](./reactions.md)** — `ReactionContent` and `Reaction` types
+  - Shared types used by `IssuesClient` reaction methods
+  - 8 reaction variants with serde rename constraints
 
 ### Infrastructure
 
-- **[pagination.md](./pagination.md)** - Pagination support
-  - PagedResponse generic type
+- **[pagination.md](./pagination.md)** — Pagination support
+  - `PagedResponse<T>` generic type
   - Link header parsing
-  - Page navigation helpers
+  - Auto-pagination helper (ADR-002)
 
-- **[rate-limiting-retry.md](./rate-limiting-retry.md)** - Rate limiting and retry logic
+- **[rate-limiting-retry.md](./rate-limiting-retry.md)** — Rate limiting and retry logic
   - Installation-level rate tracking
   - Exponential backoff with jitter
   - 429 and 403 handling
-  - Retry policy configuration
 
 ## Dependency Graph
 
 ```
-installation-client (foundation)
-    ↓
-├── repository-operations
-├── issue-operations
-├── pull-request-operations
-├── project-operations
-└── additional-operations (milestone, workflow, release)
-    ↓
-pagination (enhances list operations)
-    ↓
-rate-limiting-retry (integrates with all operations)
+InstallationClient (foundation)
+    │
+    ├── issues()         → IssuesClient      (issue.rs)
+    ├── labels()         → LabelsClient       (issue.rs)
+    ├── milestones()     → MilestonesClient   (issue.rs)
+    ├── pull_requests()  → PullRequestsClient (pull_request.rs)
+    ├── repositories()   → RepositoriesClient (repository.rs + commit.rs)
+    ├── workflows()      → WorkflowsClient    (workflow.rs)
+    ├── releases()       → ReleasesClient     (release.rs)
+    └── projects()       → ProjectsClient     (project.rs)
+                               │
+                    PagedResponse<T> (pagination.rs)
+                    Rate-limit + retry (rate_limit.rs + retry.rs)
 ```
+
+## Method Naming Conventions
+
+Methods on sub-clients drop the domain noun from their name because the sub-client
+provides the context:
+
+| Old flat API | New sub-client API |
+|---|---|
+| `client.list_issues(...)` | `client.issues().list(...)` |
+| `client.get_issue_comment(...)` | `client.issues().get_comment(...)` |
+| `client.list_labels(...)` | `client.labels().list(...)` |
+| `client.add_labels_to_issue(...)` | `client.issues().add_labels(...)` |
+| `client.get_git_ref(...)` | `client.repositories().get_ref(...)` |
+| `client.list_pull_request_reviews(...)` | `client.pull_requests().list_reviews(...)` |
+| `client.get_latest_release(...)` | `client.releases().get_latest(...)` |
+
+## ADR References
+
+- **ADR-001**: Hexagonal architecture — why business logic is separated from GitHub API adapters
+- **ADR-002**: Auto-pagination strategy — which operations use `Vec<T>` vs `PagedResponse<T>`
+- **ADR-003**: Sub-client API pattern — why domain sub-clients instead of flat methods
 
 ## Architectural Location
 

--- a/docs/specs/interfaces/README.md
+++ b/docs/specs/interfaces/README.md
@@ -147,15 +147,19 @@ All installation client interfaces are part of the **GitHub Bot SDK** library:
 
 Types are organized by domain in separate files:
 
-- `installation.rs` - InstallationClient core
-- `repository.rs` - Repository, Branch, GitRef types and operations
-- `issue.rs` - Issue, Comment, Label types and operations
-- `pull_request.rs` - PullRequest, Review types and operations
-- `milestone.rs` - Milestone types and operations
-- `workflow.rs` - Workflow, WorkflowRun types and operations
-- `release.rs` - Release types and operations
+- `installation.rs` - InstallationClient and sub-client factory methods
+- `repository.rs` - RepositoriesClient, Repository, Branch, GitRef types
+- `commit.rs` - commit operation helpers (part of RepositoriesClient)
+- `issue.rs` - IssuesClient, LabelsClient, MilestonesClient, Issue, Comment, Label, Reaction types
+- `pull_request.rs` - PullRequestsClient, PullRequest, Review types
+- `workflow.rs` - WorkflowsClient, Workflow, WorkflowRun types
+- `release.rs` - ReleasesClient, Release types
+- `project.rs` - ProjectsClient, ProjectV2 types
 - `pagination.rs` - PagedResponse generic type
 - `retry.rs` - RetryPolicy and backoff strategies
+
+**Note**: There is no `milestone.rs` file — `MilestonesClient` and all milestone types
+live in `issue.rs` (see constraints.md Sub-Client File Placement table).
 
 ## Naming Conventions
 

--- a/docs/specs/interfaces/installation-client.md
+++ b/docs/specs/interfaces/installation-client.md
@@ -316,3 +316,88 @@ After implementing this foundation, add domain-specific operations:
 - [architecture.md](../architecture.md) - Architecture boundaries and dependencies
 - [app-level-authentication.md](../architecture/app-level-authentication.md) - Authentication patterns
 - [assertions.md](../assertions.md) - Behavioral requirements
+
+---
+
+## Domain Sub-Client Factory Methods
+
+See **ADR-003** for the architectural rationale.
+
+`InstallationClient` exposes synchronous factory methods that return lightweight
+domain-scoped clients. Each factory method is infallible, makes no API call, and is
+O(1) in cost (at most an `Arc` increment).
+
+```rust
+impl InstallationClient {
+    /// Access issue-domain operations.
+    ///
+    /// Returns a client scoped to issue, comment, reaction, label-application,
+    /// assignee, lock, and timeline operations on issues.
+    ///
+    /// See docs/specs/interfaces/issue-operations.md
+    pub fn issues(&self) -> IssuesClient;
+
+    /// Access pull request operations, reviews, and inline comments.
+    ///
+    /// See docs/specs/interfaces/pull-request-operations.md
+    pub fn pull_requests(&self) -> PullRequestsClient;
+
+    /// Access repository-level label catalogue operations.
+    ///
+    /// For applying labels to issues or PRs, use the respective sub-client.
+    ///
+    /// See docs/specs/interfaces/labels-client.md
+    pub fn labels(&self) -> LabelsClient;
+
+    /// Access milestone CRUD operations.
+    ///
+    /// See docs/specs/interfaces/milestones-client.md
+    pub fn milestones(&self) -> MilestonesClient;
+
+    /// Access repository info, branch, tag, git‑ref, and commit operations.
+    ///
+    /// See docs/specs/interfaces/repository-operations.md
+    pub fn repositories(&self) -> RepositoriesClient;
+
+    /// Access GitHub Actions workflow and run operations.
+    ///
+    /// See docs/specs/interfaces/additional-operations.md
+    pub fn workflows(&self) -> WorkflowsClient;
+
+    /// Access release CRUD operations.
+    ///
+    /// See docs/specs/interfaces/additional-operations.md
+    pub fn releases(&self) -> ReleasesClient;
+
+    /// Access GitHub Projects V2 operations.
+    ///
+    /// See docs/specs/interfaces/project-operations.md
+    pub fn projects(&self) -> ProjectsClient;
+}
+```
+
+### Sub-Client Construction Constraints
+
+- Factory methods are `&self` (no exclusive ownership required).
+- Sub-clients MUST be `Clone` and `Debug`.
+- Sub-clients MUST NOT hold any mutable state.
+- Sub-clients delegate all HTTP calls back through the parent `InstallationClient`'s
+  generic `get`, `post`, `patch`, `put`, `delete` methods (or equivalent internal helpers).
+- Sub-clients MUST NOT make API calls during construction.
+
+### Example Usage
+
+```rust
+// Operations are grouped by domain:
+let issues = client.issues();
+let comments = issues.list_comments("owner", "repo", 42).await?;
+let reaction  = issues.create_reaction("owner", "repo", 42, ReactionContent::Eyes).await?;
+
+// Labels — two separate concerns:
+let label_def = client.labels().get("owner", "repo", "bug").await?;
+let updated   = client.issues().add_labels("owner", "repo", 42, vec!["bug".into()]).await?;
+
+// Milestone lifecycle:
+let ms  = client.milestones().create("owner", "repo", req).await?;
+let _   = client.issues().set_milestone("owner", "repo", 42, Some(ms.number)).await?;
+```

--- a/docs/specs/interfaces/issue-operations.md
+++ b/docs/specs/interfaces/issue-operations.md
@@ -470,6 +470,9 @@ management (creating/updating label definitions), use `LabelsClient`.
 ```rust
 impl IssuesClient {
     /// List labels currently applied to an issue.
+    ///
+    /// Auto-paginates using `per_page=100` (ADR-002). The label set per issue
+    /// is bounded; returning all at once is appropriate.
     pub async fn list_labels(
         &self,
         owner: &str,
@@ -479,7 +482,7 @@ impl IssuesClient {
 }
 ```
 
-**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/labels`
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/labels?per_page=100`
 
 ### `add_labels`
 

--- a/docs/specs/interfaces/issue-operations.md
+++ b/docs/specs/interfaces/issue-operations.md
@@ -1,136 +1,281 @@
-# Issue Operations Interface Specification
+# IssuesClient Interface Specification
 
 **Module**: `github-bot-sdk::client::issue`
-**File**: `crates/github-bot-sdk/src/client/issue.rs`
+**Struct**: `IssuesClient`
+**Obtained via**: `InstallationClient::issues()`
+**Source file**: `src/client/issue.rs`
 **Dependencies**: `InstallationClient`, `ApiError`, shared types
+
+See **ADR-003** for the sub-client pattern rationale.
 
 ## Overview
 
-Issue operations provide CRUD operations for GitHub issues, labels, and comments. These are installation-scoped operations requiring appropriate repository permissions.
+`IssuesClient` groups all operations that act on GitHub issues or objects that are
+directly attached to an issue (comments, reactions, labels on an issue, assignees,
+locks, timeline, activity events). It does **not** manage the repository-level label
+catalogue (that is `LabelsClient`) or milestone definitions (that is `MilestonesClient`).
 
-## Architectural Location
+## Sub-Client Type
 
-**Layer**: Infrastructure adapter (GitHub API operations)
-**Purpose**: Issue and label management
-**Required Permissions**: `issues:read` (minimum), `issues:write` (for mutations)
+```rust
+/// Domain client for GitHub issue operations.
+///
+/// Obtained via `InstallationClient::issues()`. Cheap to clone (Arc-backed).
+#[derive(Debug, Clone)]
+pub struct IssuesClient {
+    // Internal representation chosen by interface designer (e.g. Arc<InstallationClient>)
+}
+```
 
 ## Core Types
 
 ### Issue
 
-Represents a GitHub issue.
-
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Issue {
     pub id: u64,
+    pub node_id: String,
     pub number: u64,
     pub title: String,
     pub body: Option<String>,
-    pub state: IssueState,
-    pub user: User,
+    pub state: String,           // "open" | "closed"
+    pub locked: bool,
+    pub user: IssueUser,
+    pub assignees: Vec<IssueUser>,
     pub labels: Vec<Label>,
-    pub assignees: Vec<User>,
+    pub milestone: Option<Milestone>,
     pub comments: u64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub closed_at: Option<DateTime<Utc>>,
     pub html_url: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339::option")]
-    pub closed_at: Option<OffsetDateTime>,
-}
-```
-
-### IssueState
-
-Issue state enum.
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum IssueState {
-    Open,
-    Closed,
-}
-```
-
-### Label
-
-Represents an issue label.
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Label {
-    pub id: u64,
-    pub name: String,
-    pub description: Option<String>,
-    pub color: String,
 }
 ```
 
 ### Comment
 
-Represents an issue comment.
-
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Comment {
     pub id: u64,
+    pub node_id: String,
     pub body: String,
-    pub user: User,
+    pub user: IssueUser,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
     pub html_url: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
 }
 ```
 
-### User
-
-Represents a GitHub user.
+### IssueUser
 
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct User {
+pub struct IssueUser {
     pub login: String,
     pub id: u64,
-    pub avatar_url: String,
-    pub html_url: String,
+    pub node_id: String,
+    #[serde(rename = "type")]
+    pub user_type: String,
 }
 ```
 
-## Issue Operations
-
-### Get Issue
+### Label
 
 ```rust
-impl InstallationClient {
-    /// Get a specific issue by number.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Label {
+    pub id: u64,
+    pub node_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub color: String,
+    pub default: bool,
+}
+```
+
+### Milestone
+
+See `MilestonesClient` spec for the full type definition. `Issue` embeds a
+`Milestone` by value as returned by GitHub on issue responses.
+
+### LockReason
+
+```rust
+/// Reason used when locking an issue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockReason {
+    OffTopic,
+    TooHeated,
+    Resolved,
+    Spam,
+}
+```
+
+### IssueActivityEvent
+
+```rust
+/// A discrete activity recorded on an issue (labeling, closing, etc.).
+///
+/// Returned by the issue events REST endpoint — different from webhook events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueActivityEvent {
+    pub id: u64,
+    pub event: String,            // "labeled", "assigned", "closed", etc.
+    pub actor: IssueUser,
+    pub created_at: DateTime<Utc>,
+    pub label: Option<Label>,
+    pub assignee: Option<IssueUser>,
+    pub milestone: Option<MilestoneSummary>,
+    pub rename: Option<IssueRename>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MilestoneSummary {
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueRename {
+    pub from: String,
+    pub to: String,
+}
+```
+
+### TimelineEvent
+
+```rust
+/// A single item in an issue's timeline.
+///
+/// The `event` field drives deserialization. Unknown kinds map to `Unknown`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum TimelineEvent {
+    Commented    { id: u64, actor: IssueUser, body: String,
+                   created_at: DateTime<Utc>, updated_at: DateTime<Utc>,
+                   html_url: String },
+    Labeled      { id: u64, actor: IssueUser, label: Label,
+                   created_at: DateTime<Utc> },
+    Unlabeled    { id: u64, actor: IssueUser, label: Label,
+                   created_at: DateTime<Utc> },
+    Assigned     { id: u64, actor: IssueUser, assignee: IssueUser,
+                   created_at: DateTime<Utc> },
+    Unassigned   { id: u64, actor: IssueUser, assignee: IssueUser,
+                   created_at: DateTime<Utc> },
+    Milestoned   { id: u64, actor: IssueUser, milestone: MilestoneSummary,
+                   created_at: DateTime<Utc> },
+    Demilestoned { id: u64, actor: IssueUser, milestone: MilestoneSummary,
+                   created_at: DateTime<Utc> },
+    Closed       { id: u64, actor: IssueUser, created_at: DateTime<Utc> },
+    Reopened     { id: u64, actor: IssueUser, created_at: DateTime<Utc> },
+    Locked       { id: u64, actor: IssueUser, lock_reason: Option<String>,
+                   created_at: DateTime<Utc> },
+    Unlocked     { id: u64, actor: IssueUser, created_at: DateTime<Utc> },
+    Renamed      { id: u64, actor: IssueUser, rename: IssueRename,
+                   created_at: DateTime<Utc> },
+    Referenced   { id: u64, actor: IssueUser, created_at: DateTime<Utc> },
+    /// Catch-all: unknown event kind. Must not cause a deserialization error.
+    #[serde(other)]
+    Unknown,
+}
+```
+
+**Note**: `#[serde(other)]` on a unit variant is valid for `tag`-enums in serde when
+the fallback variant is a unit variant. Unknown fields are silently discarded. If the
+interface designer determines a different deserialization strategy is needed (e.g. to
+preserve the raw JSON), they may use a custom `Deserialize` impl instead — this spec
+only requires that unknown kinds produce no `Err`.
+
+---
+
+## Request Types
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateIssueRequest {
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignees: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub milestone: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateIssueRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,     // "open" | "closed"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignees: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub milestone: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateCommentRequest {
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateCommentRequest {
+    pub body: String,
+}
+```
+
+---
+
+## Issue CRUD Operations
+
+### `list`
+
+```rust
+impl IssuesClient {
+    /// List issues in a repository (manual pagination — callers may stop early).
     ///
     /// # Arguments
-    ///
-    /// * `owner` - Repository owner
+    /// * `owner` - Repository owner login
     /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
+    /// * `state` - Filter: `"open"` (default), `"closed"`, or `"all"`
+    /// * `page` - Page number (1-indexed); omit for first page
     ///
     /// # Returns
-    ///
-    /// Returns `Issue` with full metadata, labels, and assignees.
+    /// `PagedResponse<Issue>` — use `.has_next()` and `.next_page_number()` to paginate.
     ///
     /// # Errors
+    /// * `ApiError::NotFound` — repository doesn't exist
+    /// * `ApiError::AuthorizationFailed` — missing `issues: read`
+    pub async fn list(
+        &self,
+        owner: &str,
+        repo: &str,
+        state: Option<&str>,
+        page: Option<u32>,
+    ) -> Result<PagedResponse<Issue>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues?state={state}&page={page}`
+
+### `get`
+
+```rust
+impl IssuesClient {
+    /// Get a single issue by number.
     ///
-    /// * `ApiError::NotFound` - Issue doesn't exist
-    /// * `ApiError::PermissionDenied` - Missing `issues:read` permission
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let issue = client.get_issue("octocat", "Hello-World", 1).await?;
-    /// println!("Issue: {}", issue.title);
-    /// ```
-    pub async fn get_issue(
+    /// # Errors
+    /// * `ApiError::NotFound` — issue doesn't exist
+    pub async fn get(
         &self,
         owner: &str,
         repo: &str,
@@ -139,374 +284,60 @@ impl InstallationClient {
 }
 ```
 
-### List Issues
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}`
+
+### `create`
 
 ```rust
-impl InstallationClient {
-    /// List issues in a repository.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `params` - Optional query parameters (state, labels, assignee, etc.)
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of `Issue` objects matching criteria.
-    ///
-    /// # Notes
-    ///
-    /// Returns all matching issues (not paginated).
-    /// Future: Support pagination for repositories with many issues.
-    pub async fn list_issues(
-        &self,
-        owner: &str,
-        repo: &str,
-        params: Option<&ListIssuesParams>,
-    ) -> Result<Vec<Issue>, ApiError>;
-}
-```
-
-### Create Issue
-
-```rust
-impl InstallationClient {
+impl IssuesClient {
     /// Create a new issue.
     ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `request` - Issue creation data
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `Issue`.
-    ///
     /// # Errors
-    ///
-    /// * `ApiError::PermissionDenied` - Missing `issues:write` permission
-    /// * `ApiError::ValidationError` - Invalid title or body
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let request = CreateIssueRequest {
-    ///     title: "Bug found".to_string(),
-    ///     body: Some("Description".to_string()),
-    ///     labels: vec!["bug".to_string()],
-    ///     assignees: vec!["octocat".to_string()],
-    /// };
-    /// let issue = client.create_issue("octocat", "Hello-World", &request).await?;
-    /// ```
-    pub async fn create_issue(
+    /// * `ApiError::InvalidRequest` — validation failed (empty title, etc.)
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn create(
         &self,
         owner: &str,
         repo: &str,
-        request: &CreateIssueRequest,
+        request: CreateIssueRequest,
     ) -> Result<Issue, ApiError>;
 }
 ```
 
-### Update Issue
+**Endpoint**: `POST /repos/{owner}/{repo}/issues`
+
+### `update`
 
 ```rust
-impl InstallationClient {
-    /// Update an existing issue.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `request` - Update data (all fields optional)
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `Issue`.
+impl IssuesClient {
+    /// Update an existing issue. All fields are optional (patch semantics).
     ///
     /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue doesn't exist
-    /// * `ApiError::PermissionDenied` - Missing `issues:write` permission
-    pub async fn update_issue(
+    /// * `ApiError::NotFound` — issue doesn't exist
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn update(
         &self,
         owner: &str,
         repo: &str,
         issue_number: u64,
-        request: &UpdateIssueRequest,
+        request: UpdateIssueRequest,
     ) -> Result<Issue, ApiError>;
 }
 ```
 
-## Label Operations
+**Endpoint**: `PATCH /repos/{owner}/{repo}/issues/{issue_number}`
 
-### Get Label
+### `set_milestone`
 
 ```rust
-impl InstallationClient {
-    /// Get a repository label by name.
+impl IssuesClient {
+    /// Set (or clear) the milestone on an issue.
+    ///
+    /// Implemented as `update` with only the `milestone` field populated.
     ///
     /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `label_name` - Label name
-    ///
-    /// # Returns
-    ///
-    /// Returns `Label` with metadata.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Label doesn't exist
-    pub async fn get_label(
-        &self,
-        owner: &str,
-        repo: &str,
-        label_name: &str,
-    ) -> Result<Label, ApiError>;
-}
-```
-
-### List Labels
-
-```rust
-impl InstallationClient {
-    /// List all labels in a repository.
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of all repository labels.
-    pub async fn list_labels(
-        &self,
-        owner: &str,
-        repo: &str,
-    ) -> Result<Vec<Label>, ApiError>;
-}
-```
-
-### Create Label
-
-```rust
-impl InstallationClient {
-    /// Create a new label.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `request` - Label data (name, color, description)
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `Label`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::PermissionDenied` - Missing `issues:write`
-    /// * `ApiError::HttpError` - Label already exists (422)
-    pub async fn create_label(
-        &self,
-        owner: &str,
-        repo: &str,
-        request: &CreateLabelRequest,
-    ) -> Result<Label, ApiError>;
-}
-```
-
-### Add Labels to Issue
-
-```rust
-impl InstallationClient {
-    /// Add labels to an issue.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `labels` - Label names to add
-    ///
-    /// # Returns
-    ///
-    /// Returns updated list of issue labels.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue or label doesn't exist
-    /// * `ApiError::PermissionDenied` - Missing `issues:write`
-    pub async fn add_labels_to_issue(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        labels: &[String],
-    ) -> Result<Vec<Label>, ApiError>;
-}
-```
-
-### Remove Label from Issue
-
-```rust
-impl InstallationClient {
-    /// Remove a label from an issue.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `label_name` - Label name to remove
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue or label doesn't exist
-    /// * `ApiError::PermissionDenied` - Missing `issues:write`
-    pub async fn remove_label_from_issue(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        label_name: &str,
-    ) -> Result<(), ApiError>;
-}
-```
-
-## Comment Operations
-
-### List Comments
-
-```rust
-impl InstallationClient {
-    /// List all comments on an issue.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of comments in chronological order.
-    pub async fn list_issue_comments(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-    ) -> Result<Vec<Comment>, ApiError>;
-}
-```
-
-### Create Comment
-
-```rust
-impl InstallationClient {
-    /// Add a comment to an issue.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `body` - Comment body (Markdown supported)
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `Comment`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue doesn't exist
-    /// * `ApiError::PermissionDenied` - Missing `issues:write`
-    /// * `ApiError::ValidationError` - Empty body
-    pub async fn create_issue_comment(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        body: &str,
-    ) -> Result<Comment, ApiError>;
-}
-```
-
-### Update Comment
-
-```rust
-impl InstallationClient {
-    /// Update an issue comment.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `comment_id` - Comment ID (not issue number)
-    /// * `body` - New comment body
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `Comment`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Comment doesn't exist
-    /// * `ApiError::PermissionDenied` - Not comment author or missing permission
-    pub async fn update_issue_comment(
-        &self,
-        owner: &str,
-        repo: &str,
-        comment_id: u64,
-        body: &str,
-    ) -> Result<Comment, ApiError>;
-}
-```
-
-### Delete Comment
-
-```rust
-impl InstallationClient {
-    /// Delete an issue comment.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `comment_id` - Comment ID
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Comment doesn't exist
-    /// * `ApiError::PermissionDenied` - Not comment author or admin
-    pub async fn delete_issue_comment(
-        &self,
-        owner: &str,
-        repo: &str,
-        comment_id: u64,
-    ) -> Result<(), ApiError>;
-}
-```
-
-## Milestone Operations
-
-### Set Issue Milestone
-
-```rust
-impl InstallationClient {
-    /// Set the milestone for an issue.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `milestone_number` - Milestone number (or None to remove)
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `Issue`.
-    pub async fn set_issue_milestone(
+    /// * `milestone_number` — milestone number, or `None` to remove the milestone.
+    pub async fn set_milestone(
         &self,
         owner: &str,
         repo: &str,
@@ -516,158 +347,522 @@ impl InstallationClient {
 }
 ```
 
-**Implementation**: Uses `update_issue` with milestone field.
+---
 
-## Request Types
+## Comment Operations
 
-### CreateIssueRequest
+All comments are returned in ascending `created_at` order (oldest first — GitHub default).
+
+### `list_comments` ⚡ *auto-paginated*
 
 ```rust
-#[derive(Debug, Clone, Serialize)]
-pub struct CreateIssueRequest {
-    pub title: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub labels: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub assignees: Vec<String>,
+impl IssuesClient {
+    /// List all comments on an issue.
+    ///
+    /// Auto-paginates using `per_page=100` and follows all `Link: rel="next"`
+    /// headers (ADR-002). Returns the complete list; callers do not need to
+    /// handle pagination themselves.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — issue doesn't exist (returns immediately, no partial list)
+    pub async fn list_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<Vec<Comment>, ApiError>;
 }
 ```
 
-### UpdateIssueRequest
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/comments?per_page=100`
+
+### `get_comment`
 
 ```rust
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct UpdateIssueRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<IssueState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub labels: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub assignees: Option<Vec<String>>,
+impl IssuesClient {
+    /// Get a single comment by its ID.
+    ///
+    /// Note: comment IDs are repository-scoped, not issue-scoped.
+    pub async fn get_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+    ) -> Result<Comment, ApiError>;
 }
 ```
 
-### ListIssuesParams
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/comments/{comment_id}`
+
+### `create_comment`
 
 ```rust
-#[derive(Debug, Clone, Default)]
-pub struct ListIssuesParams {
-    pub state: Option<IssueState>,
-    pub labels: Vec<String>,
-    pub assignee: Option<String>,
+impl IssuesClient {
+    /// Add a new comment to an issue.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — issue doesn't exist
+    /// * `ApiError::InvalidRequest` — empty body
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write` or issue is locked
+    pub async fn create_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        request: CreateCommentRequest,
+    ) -> Result<Comment, ApiError>;
 }
 ```
 
-### CreateLabelRequest
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{issue_number}/comments`
+
+### `update_comment`
 
 ```rust
-#[derive(Debug, Clone, Serialize)]
-pub struct CreateLabelRequest {
-    pub name: String,
-    pub color: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+impl IssuesClient {
+    /// Update the body of an existing comment.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — comment doesn't exist
+    /// * `ApiError::AuthorizationFailed` — not the comment author or missing permission
+    pub async fn update_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        request: UpdateCommentRequest,
+    ) -> Result<Comment, ApiError>;
 }
 ```
 
-## Error Handling
+**Endpoint**: `PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}`
 
-### Permission Errors
-
-Operations requiring `issues:write`:
-
-- `create_issue`
-- `update_issue`
-- `create_label`
-- `add_labels_to_issue`
-- `remove_label_from_issue`
-- `create_issue_comment`
-- `update_issue_comment`
-- `delete_issue_comment`
-
-### Validation Errors
-
-Return `ApiError::ValidationError` when:
-
-- Issue title is empty
-- Comment body is empty
-- Label color is invalid format
-
-## Usage Examples
-
-### Create and Label an Issue
+### `delete_comment`
 
 ```rust
-let request = CreateIssueRequest {
-    title: "Bug: Application crashes on startup".to_string(),
-    body: Some("Steps to reproduce...".to_string()),
-    labels: vec!["bug".to_string(), "high-priority".to_string()],
-    assignees: vec!["maintainer".to_string()],
-};
-
-let issue = client.create_issue("owner", "repo", &request).await?;
-println!("Created issue #{}", issue.number);
+impl IssuesClient {
+    /// Delete a comment.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — comment doesn't exist
+    /// * `ApiError::AuthorizationFailed` — not the comment author or missing permission
+    pub async fn delete_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+    ) -> Result<(), ApiError>;
+}
 ```
 
-### Add Comment to Issue
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}`
+**Success**: 204 No Content
+
+---
+
+## Label Application Operations
+
+These act on labels **attached to a specific issue**. For repository-level label catalogue
+management (creating/updating label definitions), use `LabelsClient`.
+
+### `list_labels`
 
 ```rust
-let comment = client.create_issue_comment(
-    "owner",
-    "repo",
-    42,
-    "Thanks for reporting! We're investigating.",
-).await?;
+impl IssuesClient {
+    /// List labels currently applied to an issue.
+    pub async fn list_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<Vec<Label>, ApiError>;
+}
 ```
 
-### Close an Issue
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/labels`
+
+### `add_labels`
 
 ```rust
-let update = UpdateIssueRequest {
-    state: Some(IssueState::Closed),
-    ..Default::default()
-};
-
-client.update_issue("owner", "repo", 42, &update).await?;
+impl IssuesClient {
+    /// Add one or more labels to an issue.
+    ///
+    /// Labels already on the issue are ignored by GitHub (idempotent).
+    ///
+    /// # Returns
+    /// The updated label list on the issue.
+    pub async fn add_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: Vec<String>,
+    ) -> Result<Vec<Label>, ApiError>;
+}
 ```
 
-## Implementation Notes
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{issue_number}/labels`
+**Body**: `{ "labels": ["bug", "help-wanted"] }`
 
-### API Paths
+### `remove_label`
 
-- Issues: `/repos/{owner}/{repo}/issues`
-- Issue: `/repos/{owner}/{repo}/issues/{issue_number}`
-- Labels: `/repos/{owner}/{repo}/labels`
-- Issue labels: `/repos/{owner}/{repo}/issues/{issue_number}/labels`
-- Comments: `/repos/{owner}/{repo}/issues/{issue_number}/comments`
-- Comment: `/repos/{owner}/{repo}/issues/comments/{comment_id}`
+```rust
+impl IssuesClient {
+    /// Remove a single label from an issue.
+    ///
+    /// # Returns
+    /// The remaining label list.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — issue or label doesn't exist on the issue
+    pub async fn remove_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        label_name: &str,
+    ) -> Result<Vec<Label>, ApiError>;
+}
+```
 
-### Pull Requests
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{label_name}`
 
-GitHub's API returns pull requests in issue listings. To filter issues only, check that the `pull_request` field is absent.
+### `replace_labels` (atomic)
 
-### Testing Strategy
+```rust
+impl IssuesClient {
+    /// Replace all labels on an issue atomically.
+    ///
+    /// Any labels not in `labels` are removed. Labels in `labels` that do not exist
+    /// in the repository are created automatically by GitHub.
+    /// Pass an empty slice to remove all labels.
+    ///
+    /// # Returns
+    /// The new label list as applied by GitHub.
+    pub async fn replace_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: Vec<String>,
+    ) -> Result<Vec<Label>, ApiError>;
+}
+```
 
-- Mock all HTTP responses
-- Test permission error mapping
-- Test validation errors
-- Verify correct JSON serialization
+**Endpoint**: `PUT /repos/{owner}/{repo}/issues/{issue_number}/labels`
+**Body**: `{ "labels": ["enhancement"] }`
 
-## Assertions
+---
 
-Supports:
+## Reaction Operations
 
-- **Assertion #3a**: Uses installation tokens
-- **Assertion #7**: Issue management operations
+### `list_reactions` ⚡ *auto-paginated*
 
-## References
+```rust
+impl IssuesClient {
+    /// List all reactions on an issue.
+    pub async fn list_reactions(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<Vec<Reaction>, ApiError>;
+}
+```
 
-- GitHub API: [Issues](https://docs.github.com/en/rest/issues/issues)
-- GitHub API: [Labels](https://docs.github.com/en/rest/issues/labels)
-- GitHub API: [Comments](https://docs.github.com/en/rest/issues/comments)
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/reactions?per_page=100`
+
+### `create_reaction`
+
+```rust
+impl IssuesClient {
+    /// Add a reaction to an issue.
+    ///
+    /// If this user has already reacted with this emoji, GitHub returns the
+    /// existing reaction (HTTP 200). Both 200 and 201 are mapped to `Ok(Reaction)`.
+    pub async fn create_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        content: ReactionContent,
+    ) -> Result<Reaction, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{issue_number}/reactions`
+
+### `delete_reaction`
+
+```rust
+impl IssuesClient {
+    /// Remove a reaction from an issue.
+    pub async fn delete_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        reaction_id: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}`
+
+### `list_comment_reactions` ⚡ *auto-paginated*
+
+```rust
+impl IssuesClient {
+    /// List all reactions on an issue comment.
+    pub async fn list_comment_reactions(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+    ) -> Result<Vec<Reaction>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions?per_page=100`
+
+### `create_comment_reaction`
+
+```rust
+impl IssuesClient {
+    /// Add a reaction to an issue comment.
+    pub async fn create_comment_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        content: ReactionContent,
+    ) -> Result<Reaction, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions`
+
+### `delete_comment_reaction`
+
+```rust
+impl IssuesClient {
+    /// Remove a reaction from an issue comment.
+    pub async fn delete_comment_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        reaction_id: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}`
+
+---
+
+## Assignee Operations
+
+### `list_available_assignees` ⚡ *auto-paginated*
+
+```rust
+impl IssuesClient {
+    /// List users who can be assigned to issues in a repository.
+    ///
+    /// Auto-paginates (ADR-002).
+    pub async fn list_available_assignees(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<Vec<IssueUser>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/assignees?per_page=100`
+
+### `add_assignees`
+
+```rust
+impl IssuesClient {
+    /// Add assignees to an issue.
+    ///
+    /// GitHub silently ignores users who are not eligible to be assigned.
+    ///
+    /// # Returns
+    /// Updated `Issue` with the new assignee list.
+    pub async fn add_assignees(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        assignees: Vec<String>,
+    ) -> Result<Issue, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{issue_number}/assignees`
+**Body**: `{ "assignees": ["alice", "bob"] }`
+
+### `remove_assignees`
+
+```rust
+impl IssuesClient {
+    /// Remove assignees from an issue.
+    ///
+    /// GitHub silently ignores users not currently assigned.
+    ///
+    /// # Returns
+    /// Updated `Issue` with the revised assignee list.
+    pub async fn remove_assignees(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        assignees: Vec<String>,
+    ) -> Result<Issue, ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees`
+**Body**: `{ "assignees": ["alice"] }` — GitHub requires a body on this DELETE.
+
+---
+
+## Lock Operations
+
+### `lock`
+
+```rust
+impl IssuesClient {
+    /// Lock an issue, preventing non-collaborator comments.
+    ///
+    /// # Arguments
+    /// * `reason` — optional display reason shown to users attempting to comment
+    ///
+    /// # Errors
+    /// * `ApiError::AuthorizationFailed` — requires admin or maintain permission
+    pub async fn lock(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        reason: Option<LockReason>,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `PUT /repos/{owner}/{repo}/issues/{issue_number}/lock`
+**Body**: `{ "lock_reason": "too-heated" }` (field omitted when `reason` is `None`)
+**Success**: 204 No Content
+
+### `unlock`
+
+```rust
+impl IssuesClient {
+    /// Unlock a previously locked issue.
+    ///
+    /// # Errors
+    /// * `ApiError::AuthorizationFailed` — requires admin or maintain permission
+    pub async fn unlock(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock`
+**Success**: 204 No Content
+
+---
+
+## Activity & Timeline Operations
+
+### `list_activity_events` ⚡ *auto-paginated*
+
+```rust
+impl IssuesClient {
+    /// List all discrete activity events recorded on an issue.
+    ///
+    /// Returns events in ascending chronological order (oldest first).
+    /// Auto-paginates (ADR-002).
+    ///
+    /// # Examples of event kinds
+    /// `labeled`, `unlabeled`, `assigned`, `unassigned`, `milestoned`,
+    /// `demilestoned`, `closed`, `reopened`, `renamed`, `locked`, `unlocked`.
+    pub async fn list_activity_events(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<Vec<IssueActivityEvent>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/events?per_page=100`
+
+### `list_timeline` ⚡ *auto-paginated*
+
+```rust
+impl IssuesClient {
+    /// List the complete timeline of events for an issue.
+    ///
+    /// Superset of `list_activity_events`: also includes comments,
+    /// cross-references, and review events. Returns a heterogeneous
+    /// sequence; unknown event kinds deserialize to `TimelineEvent::Unknown`
+    /// without error. Auto-paginates (ADR-002).
+    pub async fn list_timeline(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<Vec<TimelineEvent>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/timeline?per_page=100`
+
+---
+
+## Permissions Summary
+
+| Method | Minimum permission |
+|--------|--------------------|
+| `list`, `get` | `issues: read` |
+| `list_comments`, `get_comment` | `issues: read` |
+| `list_labels`, `list_reactions`, `list_comment_reactions` | `issues: read` |
+| `list_available_assignees` | `issues: read` |
+| `list_activity_events`, `list_timeline` | `issues: read` |
+| `create`, `update`, `set_milestone` | `issues: write` |
+| `create_comment`, `update_comment`, `delete_comment` | `issues: write` |
+| `add_labels`, `remove_label`, `replace_labels` | `issues: write` |
+| `create_reaction`, `delete_reaction` | `issues: write` |
+| `create_comment_reaction`, `delete_comment_reaction` | `issues: write` |
+| `add_assignees`, `remove_assignees` | `issues: write` |
+| `lock`, `unlock` | admin or maintain |
+
+## Error Mapping (standard across all methods)
+
+| HTTP status | `ApiError` variant |
+|-------------|-------------------|
+| 401 | `AuthenticationFailed` |
+| 403 | `AuthorizationFailed` |
+| 404 | `NotFound` |
+| 422 | `InvalidRequest { message }` |
+| other 4xx/5xx | `HttpError { status, message }` |
+| deserialization | `HttpError` (wraps serde error) |
+
+## Testing Requirements
+
+Tests live in `src/client/issue_tests.rs` using `wiremock`. Submodules:
+
+- `construction` — struct construction, serialization of request types
+- `issue_operations` — list/get/create/update with mock HTTP responses
+- `comment_operations` — full CRUD + auto-pagination (empty, 1-page, 2-page, 404)
+- `label_operations` — add, remove, replace, list on issue
+- `reaction_operations` — all six reaction methods; duplicate-reaction (200 vs 201)
+- `assignee_operations` — add, remove, list-available
+- `lock_operations` — lock with/without reason, unlock
+- `activity_event_operations` — auto-pagination, empty list
+- `timeline_operations` — mixed event types, unknown kind → `Unknown`, empty list

--- a/docs/specs/interfaces/labels-client.md
+++ b/docs/specs/interfaces/labels-client.md
@@ -1,0 +1,211 @@
+# LabelsClient Interface Specification
+
+**Module**: `github-bot-sdk::client::issue`
+**Struct**: `LabelsClient`
+**Obtained via**: `InstallationClient::labels()`
+**Source file**: `src/client/issue.rs`
+
+See **ADR-003** for the sub-client pattern rationale.
+
+## Overview
+
+`LabelsClient` manages the **repository-level label catalogue** — the set of label
+definitions that exist in a repository. These are the labels that can be applied to
+issues and pull requests.
+
+**Scope**: `LabelsClient` operates only on label *definitions*. Applying labels to a
+specific issue is done via `IssuesClient`. Applying labels to a PR is done via
+`PullRequestsClient`.
+
+This split reflects GitHub's own API structure:
+
+| Concern | Client | GitHub endpoint |
+|---------|--------|----------------|
+| Label definition CRUD | `LabelsClient` | `/repos/{owner}/{repo}/labels` |
+| Apply label to issue | `IssuesClient` | `/repos/{owner}/{repo}/issues/{number}/labels` |
+| Apply label to PR | `PullRequestsClient` | `/repos/{owner}/{repo}/pulls/{number}/labels` |
+
+## Sub-Client Type
+
+```rust
+/// Domain client for repository-level label catalogue operations.
+///
+/// Obtained via `InstallationClient::labels()`. Cheap to clone (Arc-backed).
+#[derive(Debug, Clone)]
+pub struct LabelsClient {
+    // Internal representation chosen by interface designer
+}
+```
+
+## Types
+
+`LabelsClient` uses the shared `Label` type defined in `issue.rs` (also used by
+`IssuesClient`):
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Label {
+    pub id: u64,
+    pub node_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub color: String,        // 6-digit hex without '#'
+    pub default: bool,
+}
+```
+
+### Request Types
+
+```rust
+/// Request to create a new label definition.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateLabelRequest {
+    /// Label name (required)
+    pub name: String,
+    /// 6-digit hex color without '#' (required)
+    pub color: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Request to update an existing label definition.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateLabelRequest {
+    /// New name (renames the label — all existing references update automatically)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_name: Option<String>,
+    /// New color (6-digit hex without '#')
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+```
+
+## Operations
+
+### `list` ⚡ *auto-paginated*
+
+```rust
+impl LabelsClient {
+    /// List all label definitions in a repository.
+    ///
+    /// Auto-paginates using `per_page=100` (ADR-002). The label catalogue
+    /// is bounded in size; returning all at once is appropriate.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — repository doesn't exist
+    pub async fn list(&self, owner: &str, repo: &str) -> Result<Vec<Label>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/labels?per_page=100`
+
+### `get`
+
+```rust
+impl LabelsClient {
+    /// Get a single label definition by name.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — label doesn't exist
+    pub async fn get(&self, owner: &str, repo: &str, name: &str) -> Result<Label, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/labels/{name}`
+
+### `create`
+
+```rust
+impl LabelsClient {
+    /// Create a new label definition.
+    ///
+    /// # Errors
+    /// * `ApiError::InvalidRequest` — label with this name already exists (422)
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn create(
+        &self,
+        owner: &str,
+        repo: &str,
+        request: CreateLabelRequest,
+    ) -> Result<Label, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/labels`
+
+### `update`
+
+```rust
+impl LabelsClient {
+    /// Update an existing label definition.
+    ///
+    /// Renaming a label via `new_name` updates all existing issue/PR references.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — label doesn't exist
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn update(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+        request: UpdateLabelRequest,
+    ) -> Result<Label, ApiError>;
+}
+```
+
+**Endpoint**: `PATCH /repos/{owner}/{repo}/labels/{name}`
+
+### `delete`
+
+```rust
+impl LabelsClient {
+    /// Delete a label definition.
+    ///
+    /// Deleting a label removes it from all issues and PRs it was applied to.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — label doesn't exist
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn delete(&self, owner: &str, repo: &str, name: &str) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/labels/{name}`
+**Success**: 204 No Content
+
+## Permissions
+
+| Method | Minimum permission |
+|--------|--------------------|
+| `list`, `get` | `issues: read` |
+| `create`, `update`, `delete` | `issues: write` |
+
+## Error Mapping
+
+| HTTP status | `ApiError` variant |
+|-------------|-------------------|
+| 401 | `AuthenticationFailed` |
+| 403 | `AuthorizationFailed` |
+| 404 | `NotFound` |
+| 422 | `InvalidRequest { message }` |
+| other | `HttpError { status, message }` |
+
+## Testing Requirements
+
+Tests live in `src/client/issue_tests.rs` in a `label_catalogue_operations` submodule.
+
+| Scenario | Expected |
+|----------|---------|
+| `list` — empty repository | `Ok(vec![])` |
+| `list` — multi-page | Auto-paginates, returns all |
+| `get` — existing label | `Ok(Label)` with correct fields |
+| `get` — not found | `Err(ApiError::NotFound)` |
+| `create` — success | `Ok(Label)` with id assigned |
+| `create` — duplicate name | `Err(ApiError::InvalidRequest)` |
+| `update` — rename | `Ok(Label)` with new name |
+| `update` — not found | `Err(ApiError::NotFound)` |
+| `delete` — success | `Ok(())` |
+| `delete` — not found | `Err(ApiError::NotFound)` |

--- a/docs/specs/interfaces/labels-client.md
+++ b/docs/specs/interfaces/labels-client.md
@@ -71,8 +71,12 @@ pub struct CreateLabelRequest {
 /// Request to update an existing label definition.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct UpdateLabelRequest {
-    /// New name (renames the label — all existing references update automatically)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// New name (renames the label — all existing references update automatically).
+    ///
+    /// The field is called `new_name` in Rust to distinguish it from the `name`
+    /// path parameter on the `update` method. The GitHub API expects the JSON key
+    /// to be `"name"`, so the serde rename is required.
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub new_name: Option<String>,
     /// New color (6-digit hex without '#')
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/docs/specs/interfaces/milestones-client.md
+++ b/docs/specs/interfaces/milestones-client.md
@@ -1,0 +1,272 @@
+# MilestonesClient Interface Specification
+
+**Module**: `github-bot-sdk::client::issue`
+**Struct**: `MilestonesClient`
+**Obtained via**: `InstallationClient::milestones()`
+**Source file**: `src/client/issue.rs`
+
+See **ADR-003** for the sub-client pattern rationale.
+
+## Overview
+
+`MilestonesClient` manages repository milestones — named progress markers that group
+issues and pull requests. Milestones are repository-level entities with their own
+CRUD lifecycle.
+
+**Scope**: `MilestonesClient` owns milestone definitions. Assigning a milestone to a
+specific issue is done via `IssuesClient::set_milestone`. Assigning to a PR is done via
+`PullRequestsClient::set_milestone`.
+
+## Sub-Client Type
+
+```rust
+/// Domain client for milestone lifecycle operations.
+///
+/// Obtained via `InstallationClient::milestones()`. Cheap to clone (Arc-backed).
+#[derive(Debug, Clone)]
+pub struct MilestonesClient {
+    // Internal representation chosen by interface designer
+}
+```
+
+## Types
+
+### `Milestone`
+
+Reused from the shared type in `issue.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Milestone {
+    pub id: u64,
+    pub node_id: String,
+    pub number: u64,
+    pub title: String,
+    pub description: Option<String>,
+    pub state: MilestoneState,
+    pub due_on: Option<DateTime<Utc>>,
+    pub open_issues: u32,
+    pub closed_issues: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub closed_at: Option<DateTime<Utc>>,
+}
+```
+
+### `MilestoneState`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MilestoneState {
+    Open,
+    Closed,
+}
+```
+
+### Request Types
+
+```rust
+/// Request to create a new milestone.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateMilestoneRequest {
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<MilestoneState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// ISO 8601 format (GitHub expects this)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub due_on: Option<DateTime<Utc>>,
+}
+
+/// Request to update an existing milestone.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateMilestoneRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<MilestoneState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub due_on: Option<DateTime<Utc>>,
+}
+
+/// Filter and sort options for listing milestones.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListMilestonesQuery {
+    /// Filter by state; default `open`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<MilestoneState>,
+    /// Sort by `due_on` or `completeness`; default `due_on`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<MilestoneSortField>,
+    /// Sort direction; default `asc`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<SortDirection>,
+}
+```
+
+### `MilestoneSortField`
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MilestoneSortField {
+    DueOn,
+    Completeness,
+}
+```
+
+## Operations
+
+### `list` ⚡ *auto-paginated*
+
+```rust
+impl MilestonesClient {
+    /// List all milestones in a repository.
+    ///
+    /// Auto-paginates using `per_page=100` (ADR-002).
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — repository doesn't exist
+    pub async fn list(
+        &self,
+        owner: &str,
+        repo: &str,
+        query: Option<ListMilestonesQuery>,
+    ) -> Result<Vec<Milestone>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/milestones?per_page=100[&state=..][&sort=..][&direction=..]`
+
+### `get`
+
+```rust
+impl MilestonesClient {
+    /// Get a single milestone by its number.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — milestone doesn't exist
+    pub async fn get(
+        &self,
+        owner: &str,
+        repo: &str,
+        milestone_number: u64,
+    ) -> Result<Milestone, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/milestones/{milestone_number}`
+
+### `create`
+
+```rust
+impl MilestonesClient {
+    /// Create a new milestone.
+    ///
+    /// # Errors
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    /// * `ApiError::InvalidRequest` — title is empty
+    pub async fn create(
+        &self,
+        owner: &str,
+        repo: &str,
+        request: CreateMilestoneRequest,
+    ) -> Result<Milestone, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/milestones`
+
+### `update`
+
+```rust
+impl MilestonesClient {
+    /// Update an existing milestone.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — milestone doesn't exist
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn update(
+        &self,
+        owner: &str,
+        repo: &str,
+        milestone_number: u64,
+        request: UpdateMilestoneRequest,
+    ) -> Result<Milestone, ApiError>;
+}
+```
+
+**Endpoint**: `PATCH /repos/{owner}/{repo}/milestones/{milestone_number}`
+
+### `delete`
+
+```rust
+impl MilestonesClient {
+    /// Delete a milestone.
+    ///
+    /// Issues assigned to the deleted milestone are unlinked but otherwise
+    /// unaffected. This operation cannot be undone.
+    ///
+    /// # Errors
+    /// * `ApiError::NotFound` — milestone doesn't exist
+    /// * `ApiError::AuthorizationFailed` — missing `issues: write`
+    pub async fn delete(
+        &self,
+        owner: &str,
+        repo: &str,
+        milestone_number: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/milestones/{milestone_number}`
+**Success**: 204 No Content
+
+## Permissions
+
+| Method | Minimum permission |
+|--------|--------------------|
+| `list`, `get` | `issues: read` |
+| `create`, `update`, `delete` | `issues: write` |
+
+## Error Mapping
+
+| HTTP status | `ApiError` variant |
+|-------------|-------------------|
+| 401 | `AuthenticationFailed` |
+| 403 | `AuthorizationFailed` |
+| 404 | `NotFound` |
+| 422 | `InvalidRequest { message }` |
+| other | `HttpError { status, message }` |
+
+## Edge Cases
+
+- **Deleting a milestone with open issues**: Issues are unlinked (milestone set to `null`)
+  but remain open. Callers that rely on milestone membership for triage should query
+  issues before deleting.
+- **Past-due milestones**: `due_on` in the past is accepted; GitHub does not reject it.
+  The `state` field must be set to `closed` explicitly to close a past-due milestone.
+- **Closed milestone listing**: `list` with `state: closed` returns milestones that no
+  longer actively track work; useful for audit/history use cases.
+
+## Testing Requirements
+
+Tests live in `src/client/issue_tests.rs` in a `milestone_operations` submodule.
+
+| Scenario | Expected |
+|----------|---------|
+| `list` — empty milestones | `Ok(vec![])` |
+| `list` — with `state: closed` | Returns only closed milestones |
+| `list` — multi-page | Auto-paginates, returns all |
+| `get` — existing milestone | `Ok(Milestone)` with correct fields |
+| `get` — not found | `Err(ApiError::NotFound)` |
+| `create` — success | `Ok(Milestone)` with number assigned |
+| `create` — with `due_on` | `Ok(Milestone)` with `due_on` set |
+| `update` — close milestone | `Ok(Milestone)` with `state: closed` |
+| `update` — not found | `Err(ApiError::NotFound)` |
+| `delete` — success | `Ok(())` |
+| `delete` — not found | `Err(ApiError::NotFound)` |

--- a/docs/specs/interfaces/milestones-client.md
+++ b/docs/specs/interfaces/milestones-client.md
@@ -119,6 +119,22 @@ pub enum MilestoneSortField {
 }
 ```
 
+### `SortDirection`
+
+```rust
+/// Sort direction for list queries.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+```
+
+This type is shared across domain clients. The interface designer may hoist it to a
+common module (e.g. `src/client/mod.rs`) so it can be reused by `list_commits`,
+`list_milestones`, and any future sorted-list operations without duplication.
+
 ## Operations
 
 ### `list` ⚡ *auto-paginated*

--- a/docs/specs/interfaces/pull-request-operations.md
+++ b/docs/specs/interfaces/pull-request-operations.md
@@ -1,18 +1,37 @@
-# Pull Request Operations Interface Specification
+# PullRequestsClient Interface Specification
 
 **Module**: `github-bot-sdk::client::pull_request`
-**File**: `crates/github-bot-sdk/src/client/pull_request.rs`
-**Dependencies**: `InstallationClient`, `ApiError`, issue types (User, Label), shared types
+**Struct**: `PullRequestsClient`
+**Obtained via**: `InstallationClient::pull_requests()`
+**Source file**: `src/client/pull_request.rs`
+
+See **ADR-003** for the sub-client pattern rationale.
 
 ## Overview
 
-Pull request operations provide access to PR management, reviews, and merge operations. These are installation-scoped operations requiring appropriate repository permissions.
+`PullRequestsClient` provides PR management, review management, inline comments,
+label application, and merge operations scoped to pull requests.
 
-## Architectural Location
+## Sub-Client Type
 
-**Layer**: Infrastructure adapter (GitHub API operations)
-**Purpose**: Pull request and review management
-**Required Permissions**: `pull_requests:read` (minimum), `pull_requests:write` (for mutations)
+```rust
+/// Domain client for pull request operations.
+///
+/// Obtained via `InstallationClient::pull_requests()`. Cheap to clone (Arc-backed).
+#[derive(Debug, Clone)]
+pub struct PullRequestsClient {
+    // Internal representation chosen by interface designer
+}
+```
+
+## Permissions
+
+| Operation group | Minimum permission |
+|----------------|--------------------|
+| `list`, `get` | `pull_requests: read` |
+| `create`, `update`, `merge` | `pull_requests: write` |
+| Reviews | `pull_requests: write` |
+| Comments | `pull_requests: write` (write) / `pull_requests: read` (list) |
 
 ## Core Types
 
@@ -114,27 +133,16 @@ pub enum ReviewState {
 
 ## Pull Request Operations
 
-### Get Pull Request
+### `get`
 
 ```rust
-impl InstallationClient {
+impl PullRequestsClient {
     /// Get a specific pull request by number.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    ///
-    /// # Returns
-    ///
-    /// Returns `PullRequest` with full metadata.
     ///
     /// # Errors
     ///
-    /// * `ApiError::NotFound` - PR doesn't exist
-    /// * `ApiError::PermissionDenied` - Missing `pull_requests:read`
-    pub async fn get_pull_request(
+    /// * `ApiError::NotFound` — PR doesn't exist
+    pub async fn get(
         &self,
         owner: &str,
         repo: &str,
@@ -143,51 +151,37 @@ impl InstallationClient {
 }
 ```
 
-### List Pull Requests
+**Endpoint**: `GET /repos/{owner}/{repo}/pulls/{pull_number}`
+
+### `list`
+
+Returns the first page of pull requests matching the filter criteria (manual pagination).
 
 ```rust
-impl InstallationClient {
+impl PullRequestsClient {
     /// List pull requests in a repository.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `params` - Optional query parameters (state, head, base, etc.)
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of pull requests matching criteria.
-    pub async fn list_pull_requests(
+    pub async fn list(
         &self,
         owner: &str,
         repo: &str,
         params: Option<&ListPullRequestsParams>,
-    ) -> Result<Vec<PullRequest>, ApiError>;
+    ) -> Result<PagedResponse<PullRequest>, ApiError>;
 }
 ```
 
-### Create Pull Request
+**Endpoint**: `GET /repos/{owner}/{repo}/pulls`
+
+### `create`
 
 ```rust
-impl InstallationClient {
+impl PullRequestsClient {
     /// Create a new pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `request` - PR creation data
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `PullRequest`.
     ///
     /// # Errors
     ///
-    /// * `ApiError::PermissionDenied` - Missing `pull_requests:write`
-    /// * `ApiError::HttpError` - Invalid branch or no commits (422)
-    pub async fn create_pull_request(
+    /// * `ApiError::AuthorizationFailed` — Missing `pull_requests: write`
+    /// * `ApiError::InvalidRequest` — Invalid branch or no commits (422)
+    pub async fn create(
         &self,
         owner: &str,
         repo: &str,
@@ -196,23 +190,14 @@ impl InstallationClient {
 }
 ```
 
-### Update Pull Request
+**Endpoint**: `POST /repos/{owner}/{repo}/pulls`
+
+### `update`
 
 ```rust
-impl InstallationClient {
+impl PullRequestsClient {
     /// Update an existing pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `request` - Update data
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `PullRequest`.
-    pub async fn update_pull_request(
+    pub async fn update(
         &self,
         owner: &str,
         repo: &str,
@@ -222,28 +207,20 @@ impl InstallationClient {
 }
 ```
 
-### Merge Pull Request
+**Endpoint**: `PATCH /repos/{owner}/{repo}/pulls/{pull_number}`
+
+### `merge`
 
 ```rust
-impl InstallationClient {
+impl PullRequestsClient {
     /// Merge a pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `request` - Merge options
-    ///
-    /// # Returns
-    ///
-    /// Returns merge result with SHA and status.
     ///
     /// # Errors
     ///
-    /// * `ApiError::PermissionDenied` - Missing merge permission
-    /// * `ApiError::HttpError` - Not mergeable (405), conflicts exist (409)
-    pub async fn merge_pull_request(
+    /// * `ApiError::AuthorizationFailed` — Missing merge permission
+    /// * `ApiError::HttpError { status: 405 }` — Not mergeable
+    /// * `ApiError::HttpError { status: 409 }` — Merge conflict
+    pub async fn merge(
         &self,
         owner: &str,
         repo: &str,
@@ -253,185 +230,16 @@ impl InstallationClient {
 }
 ```
 
-## Review Operations
+**Endpoint**: `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge`
 
-### List Reviews
-
-```rust
-impl InstallationClient {
-    /// List reviews for a pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of reviews in chronological order.
-    pub async fn list_pull_request_reviews(
-        &self,
-        owner: &str,
-        repo: &str,
-        pull_number: u64,
-    ) -> Result<Vec<Review>, ApiError>;
-}
-```
-
-### Create Review
+### `set_milestone`
 
 ```rust
-impl InstallationClient {
-    /// Create a review for a pull request.
+impl PullRequestsClient {
+    /// Set (or clear) the milestone on a pull request.
     ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `request` - Review data
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `Review`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::PermissionDenied` - Missing permission
-    /// * `ApiError::HttpError` - Already reviewed (422)
-    pub async fn create_pull_request_review(
-        &self,
-        owner: &str,
-        repo: &str,
-        pull_number: u64,
-        request: &CreateReviewRequest,
-    ) -> Result<Review, ApiError>;
-}
-```
-
-## Comment Operations
-
-Pull requests support issue-style comments (separate from review comments).
-
-### List PR Comments
-
-```rust
-impl InstallationClient {
-    /// List all comments on a pull request.
-    ///
-    /// These are issue-style comments, not review comments.
-    /// For review comments, use `list_pull_request_reviews`.
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of comments in chronological order.
-    pub async fn list_pull_request_comments(
-        &self,
-        owner: &str,
-        repo: &str,
-        pull_number: u64,
-    ) -> Result<Vec<Comment>, ApiError>;
-}
-```
-
-### Create PR Comment
-
-```rust
-impl InstallationClient {
-    /// Add a comment to a pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `body` - Comment body (Markdown supported)
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `Comment`.
-    pub async fn create_pull_request_comment(
-        &self,
-        owner: &str,
-        repo: &str,
-        pull_number: u64,
-        body: &str,
-    ) -> Result<Comment, ApiError>;
-}
-```
-
-## Label Operations
-
-Pull requests use the same label operations as issues.
-
-### Add Labels to PR
-
-```rust
-impl InstallationClient {
-    /// Add labels to a pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `labels` - Label names to add
-    ///
-    /// # Returns
-    ///
-    /// Returns updated list of PR labels.
-    pub async fn add_labels_to_pull_request(
-        &self,
-        owner: &str,
-        repo: &str,
-        pull_number: u64,
-        labels: &[String],
-    ) -> Result<Vec<Label>, ApiError>;
-}
-```
-
-### Remove Label from PR
-
-```rust
-impl InstallationClient {
-    /// Remove a label from a pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `label_name` - Label name to remove
-    pub async fn remove_label_from_pull_request(
-        &self,
-        owner: &str,
-        repo: &str,
-        pull_number: u64,
-        label_name: &str,
-    ) -> Result<(), ApiError>;
-}
-```
-
-## Milestone Operations
-
-### Set PR Milestone
-
-```rust
-impl InstallationClient {
-    /// Set the milestone for a pull request.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `pull_number` - Pull request number
-    /// * `milestone_number` - Milestone number (or None to remove)
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `PullRequest`.
-    pub async fn set_pull_request_milestone(
+    /// Pass `None` to remove the milestone from the PR.
+    pub async fn set_milestone(
         &self,
         owner: &str,
         repo: &str,
@@ -441,7 +249,246 @@ impl InstallationClient {
 }
 ```
 
-**Implementation**: Uses `update_pull_request` with milestone field.
+**Implementation**: Delegates to `update()` with the `milestone` field set.
+
+## Review Operations
+
+Review methods use the `list_reviews` / `get_review` / etc. naming style (not prefixed
+with `pull_request_`) because the sub-client context makes the domain clear.
+
+### `list_reviews`
+
+```rust
+impl PullRequestsClient {
+    /// List reviews for a pull request in chronological order.
+    pub async fn list_reviews(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<Vec<Review>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews`
+
+### `get_review`
+
+```rust
+impl PullRequestsClient {
+    /// Get a single review by ID.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` — Review doesn't exist on this PR
+    pub async fn get_review(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        review_id: u64,
+    ) -> Result<Review, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}`
+
+### `create_review`
+
+```rust
+impl PullRequestsClient {
+    /// Create a review for a pull request.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::AuthorizationFailed` — Missing `pull_requests: write`
+    /// * `ApiError::InvalidRequest` — Already reviewed (422)
+    pub async fn create_review(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        request: &CreateReviewRequest,
+    ) -> Result<Review, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`
+
+### `update_review`
+
+```rust
+impl PullRequestsClient {
+    /// Update the body of an existing pending review.
+    pub async fn update_review(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        review_id: u64,
+        body: &str,
+    ) -> Result<Review, ApiError>;
+}
+```
+
+**Endpoint**: `PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}`
+
+### `dismiss_review`
+
+```rust
+impl PullRequestsClient {
+    /// Dismiss a submitted review.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::AuthorizationFailed` — Only maintainers can dismiss reviews
+    pub async fn dismiss_review(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        review_id: u64,
+        message: &str,
+    ) -> Result<Review, ApiError>;
+}
+```
+
+**Endpoint**: `PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals`
+
+## Comment Operations
+
+Pull requests support issue-style comments (on the conversation thread), separate from
+review comments (inline code comments attached to a file diff).
+
+### `list_comments`
+
+```rust
+impl PullRequestsClient {
+    /// List all conversation-thread comments on a pull request.
+    ///
+    /// These are issue-body-style comments. For review comments (inline code
+    /// annotations), use `list_reviews`.
+    ///
+    /// Auto-paginates (ADR-002).
+    pub async fn list_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<Vec<Comment>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{pull_number}/comments?per_page=100`
+
+*Note*: GitHub routes PR conversation comments through the Issues comments endpoint.
+
+### `create_comment`
+
+```rust
+impl PullRequestsClient {
+    /// Add a conversation-thread comment to a pull request.
+    pub async fn create_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        body: &str,
+    ) -> Result<Comment, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{pull_number}/comments`
+
+### `update_comment`
+
+```rust
+impl PullRequestsClient {
+    /// Update the body of a conversation-thread comment.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` — comment doesn't exist
+    /// * `ApiError::AuthorizationFailed` — not the comment author
+    pub async fn update_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        body: &str,
+    ) -> Result<Comment, ApiError>;
+}
+```
+
+**Endpoint**: `PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}`
+
+### `delete_comment`
+
+```rust
+impl PullRequestsClient {
+    /// Delete a conversation-thread comment.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` — comment doesn't exist
+    /// * `ApiError::AuthorizationFailed` — not the comment author
+    pub async fn delete_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}`
+**Success**: 204 No Content
+
+## Label Operations
+
+### `add_labels`
+
+```rust
+impl PullRequestsClient {
+    /// Add labels to a pull request.
+    ///
+    /// Labels must already exist in the repository label catalogue (`LabelsClient`).
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated set of labels on the PR.
+    pub async fn add_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        labels: &[String],
+    ) -> Result<Vec<Label>, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{pull_number}/labels`
+
+### `remove_label`
+
+```rust
+impl PullRequestsClient {
+    /// Remove a single label from a pull request.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` — label not applied to this PR
+    pub async fn remove_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        label_name: &str,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{pull_number}/labels/{label_name}`
 
 ## Request Types
 

--- a/docs/specs/interfaces/pull-request-operations.md
+++ b/docs/specs/interfaces/pull-request-operations.md
@@ -128,6 +128,10 @@ pub enum ReviewState {
     ChangesRequested,
     Commented,
     Dismissed,
+    /// Review started but not yet submitted. GitHub returns this for in-progress
+    /// review drafts. Without this variant, deserializing a PR with a pending
+    /// review draft would produce a serde error.
+    Pending,
 }
 ```
 
@@ -260,7 +264,10 @@ with `pull_request_`) because the sub-client context makes the domain clear.
 
 ```rust
 impl PullRequestsClient {
-    /// List reviews for a pull request in chronological order.
+    /// List all reviews for a pull request in chronological order.
+    ///
+    /// Auto-paginates using `per_page=100` (ADR-002). The review set per PR is
+    /// bounded and callers typically need the complete history.
     pub async fn list_reviews(
         &self,
         owner: &str,
@@ -270,7 +277,7 @@ impl PullRequestsClient {
 }
 ```
 
-**Endpoint**: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews`
+**Endpoint**: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews?per_page=100`
 
 ### `get_review`
 
@@ -475,6 +482,10 @@ impl PullRequestsClient {
 impl PullRequestsClient {
     /// Remove a single label from a pull request.
     ///
+    /// # Returns
+    ///
+    /// The remaining labels on the PR after removal.
+    ///
     /// # Errors
     ///
     /// * `ApiError::NotFound` — label not applied to this PR
@@ -484,7 +495,7 @@ impl PullRequestsClient {
         repo: &str,
         pull_number: u64,
         label_name: &str,
-    ) -> Result<(), ApiError>;
+    ) -> Result<Vec<Label>, ApiError>;
 }
 ```
 
@@ -609,9 +620,10 @@ let request = CreatePullRequestRequest {
     base: "main".to_string(),
     body: Some("Description of changes".to_string()),
     draft: Some(false),
+    ..Default::default()
 };
 
-let pr = client.create_pull_request("owner", "repo", &request).await?;
+let pr = client.pull_requests().create("owner", "repo", &request).await?;
 println!("Created PR #{}", pr.number);
 ```
 
@@ -623,7 +635,7 @@ let review = CreateReviewRequest {
     event: ReviewEvent::Approve,
 };
 
-client.create_pull_request_review("owner", "repo", 42, &review).await?;
+client.pull_requests().create_review("owner", "repo", 42, &review).await?;
 ```
 
 ### Merge a Pull Request
@@ -635,7 +647,7 @@ let merge_opts = MergePullRequestRequest {
     ..Default::default()
 };
 
-let result = client.merge_pull_request("owner", "repo", 42, Some(&merge_opts)).await?;
+let result = client.pull_requests().merge("owner", "repo", 42, Some(&merge_opts)).await?;
 println!("Merged: {}", result.sha);
 ```
 

--- a/docs/specs/interfaces/reactions.md
+++ b/docs/specs/interfaces/reactions.md
@@ -1,0 +1,327 @@
+# Reactions Interface Specification
+
+**Module**: `github-bot-sdk::client::issue` (extends `issue.rs`)
+**Dependencies**: `InstallationClient`, `ApiError`, `IssueUser`, `Comment`
+
+## Overview
+
+Reactions allow GitHub Apps and bots to respond to issues and comments with emoji
+acknowledgements (👍 👎 😄 etc.). They are lightweight signals that do not clutter the
+comment thread. Bots commonly use reactions to:
+
+- Acknowledge receipt of a command (👀 = "I see it")
+- Signal success or failure (✅ ❌)
+- Let humans vote on proposals (👍 👎)
+
+Reactions live at two attachment points in the API:
+
+| Attachment | Endpoint |
+|-----------|---------|
+| Issue | `/repos/{owner}/{repo}/issues/{issue_number}/reactions` |
+| Issue comment | `/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions` |
+
+## Types
+
+### ReactionContent
+
+```rust
+/// Emoji content for a reaction, as accepted by the GitHub API.
+///
+/// GitHub uses these exact string values in JSON; the serde representation
+/// matches GitHub's API names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReactionContent {
+    /// 👍
+    #[serde(rename = "+1")]
+    PlusOne,
+    /// 👎
+    #[serde(rename = "-1")]
+    MinusOne,
+    /// 😄
+    Laugh,
+    /// 😕
+    Confused,
+    /// ❤️
+    Heart,
+    /// 🎉
+    Hooray,
+    /// 🚀
+    Rocket,
+    /// 👀
+    Eyes,
+}
+```
+
+**Implementation note**: `+1` and `-1` are the only reactions whose API names start with
+symbols rather than letters. Explicit `#[serde(rename = "...")]` attributes are required
+for those two variants.
+
+### Reaction
+
+```rust
+/// A single reaction on an issue or comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reaction {
+    /// Unique reaction identifier
+    pub id: u64,
+
+    /// Node ID for GraphQL API
+    pub node_id: String,
+
+    /// User who reacted
+    pub user: IssueUser,
+
+    /// The emoji content of this reaction
+    pub content: ReactionContent,
+
+    /// When the reaction was created (UTC)
+    pub created_at: DateTime<Utc>,
+}
+```
+
+## Issue Reaction Operations
+
+### List Issue Reactions
+
+```rust
+impl InstallationClient {
+    /// List all reactions on an issue.
+    ///
+    /// Auto-paginates through all results (see ADR-002).
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - Repository owner
+    /// * `repo` - Repository name
+    /// * `issue_number` - Issue number
+    ///
+    /// # Returns
+    ///
+    /// All reactions on the issue, across all pages.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` - Issue doesn't exist
+    /// * `ApiError::AuthorizationFailed` - Missing `issues:read`
+    pub async fn list_issue_reactions(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Result<Vec<Reaction>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/reactions?per_page=100`
+
+### Create Issue Reaction
+
+```rust
+impl InstallationClient {
+    /// Add a reaction to an issue.
+    ///
+    /// If the authenticated user has already reacted with this emoji,
+    /// GitHub returns the existing reaction (200) rather than creating a
+    /// duplicate (201). Both cases return `Ok(Reaction)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - Repository owner
+    /// * `repo` - Repository name
+    /// * `issue_number` - Issue number
+    /// * `content` - The emoji reaction to add
+    ///
+    /// # Returns
+    ///
+    /// The created or existing `Reaction`.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` - Issue doesn't exist
+    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
+    pub async fn create_issue_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        content: ReactionContent,
+    ) -> Result<Reaction, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/{issue_number}/reactions`
+**Body**: `{ "content": "+1" }`
+**Success codes**: 200 (already exists) and 201 (created) both succeed.
+
+### Delete Issue Reaction
+
+```rust
+impl InstallationClient {
+    /// Remove a reaction from an issue.
+    ///
+    /// Only the authenticated user can delete their own reactions.
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - Repository owner
+    /// * `repo` - Repository name
+    /// * `issue_number` - Issue number
+    /// * `reaction_id` - ID of the reaction to remove
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` - Issue or reaction doesn't exist
+    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
+    pub async fn delete_issue_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        reaction_id: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}`
+**Success code**: 204 No Content
+
+## Issue Comment Reaction Operations
+
+### List Comment Reactions
+
+```rust
+impl InstallationClient {
+    /// List all reactions on an issue comment.
+    ///
+    /// Auto-paginates through all results (see ADR-002).
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - Repository owner
+    /// * `repo` - Repository name
+    /// * `comment_id` - Comment ID (not the issue number)
+    ///
+    /// # Returns
+    ///
+    /// All reactions on the comment, across all pages.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` - Comment doesn't exist
+    /// * `ApiError::AuthorizationFailed` - Missing `issues:read`
+    pub async fn list_comment_reactions(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+    ) -> Result<Vec<Reaction>, ApiError>;
+}
+```
+
+**Endpoint**: `GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions?per_page=100`
+
+### Create Comment Reaction
+
+```rust
+impl InstallationClient {
+    /// Add a reaction to an issue comment.
+    ///
+    /// If the authenticated user has already reacted with this emoji,
+    /// GitHub returns the existing reaction (200) rather than a duplicate.
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - Repository owner
+    /// * `repo` - Repository name
+    /// * `comment_id` - Comment ID (not the issue number)
+    /// * `content` - The emoji reaction to add
+    ///
+    /// # Returns
+    ///
+    /// The created or existing `Reaction`.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` - Comment doesn't exist
+    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
+    pub async fn create_comment_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        content: ReactionContent,
+    ) -> Result<Reaction, ApiError>;
+}
+```
+
+**Endpoint**: `POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions`
+**Body**: `{ "content": "eyes" }`
+**Success codes**: 200 (already exists) and 201 (created) both succeed.
+
+### Delete Comment Reaction
+
+```rust
+impl InstallationClient {
+    /// Remove a reaction from an issue comment.
+    ///
+    /// Only the authenticated user can delete their own reactions.
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - Repository owner
+    /// * `repo` - Repository name
+    /// * `comment_id` - Comment ID (not the issue number)
+    /// * `reaction_id` - ID of the reaction to remove
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::NotFound` - Comment or reaction doesn't exist
+    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
+    pub async fn delete_comment_reaction(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        reaction_id: u64,
+    ) -> Result<(), ApiError>;
+}
+```
+
+**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}`
+**Success code**: 204 No Content
+
+## Implementation Location
+
+All reaction types and methods are added to `src/client/issue.rs`, consistent with the
+existing placement of all issue-domain types. No new source file is needed.
+
+## Error Handling
+
+All reaction operations inherit the standard error mapping:
+
+| HTTP status | `ApiError` variant |
+|------------|-------------------|
+| 401 | `AuthenticationFailed` |
+| 403 | `AuthorizationFailed` |
+| 404 | `NotFound` |
+| 422 | `InvalidRequest { message }` |
+| other | `HttpError { status, message }` |
+
+## Testing Requirements
+
+Per `docs/standards/testing.md`, unit tests must cover:
+
+| Scenario | Expected |
+|---------|---------|
+| `list_issue_reactions` — empty | Returns `Ok(vec![])` |
+| `list_issue_reactions` — single page | Returns all items |
+| `list_issue_reactions` — multi-page | Follows `Link: rel="next"`, returns all |
+| `create_issue_reaction` — 201 Created | Returns `Ok(Reaction)` |
+| `create_issue_reaction` — 200 (duplicate) | Returns `Ok(Reaction)` |
+| `create_issue_reaction` — issue not found | Returns `Err(ApiError::NotFound)` |
+| `delete_issue_reaction` — success | Returns `Ok(())` |
+| `delete_issue_reaction` — not found | Returns `Err(ApiError::NotFound)` |
+| Same scenarios repeated for comment reactions | — |
+
+Tests live in `src/client/issue_tests.rs` in a `reaction_operations` submodule.

--- a/docs/specs/interfaces/reactions.md
+++ b/docs/specs/interfaces/reactions.md
@@ -1,7 +1,14 @@
 # Reactions Interface Specification
 
-**Module**: `github-bot-sdk::client::issue` (extends `issue.rs`)
-**Dependencies**: `InstallationClient`, `ApiError`, `IssueUser`, `Comment`
+**Module**: `github-bot-sdk::client::issue`
+**Contained in**: `src/client/issue.rs`
+
+> **Scope**: This file defines the *types* only. The reaction methods themselves
+> (`list_reactions`, `create_reaction`, `delete_reaction`, `list_comment_reactions`,
+> `create_comment_reaction`, `delete_comment_reaction`) are specified in
+> `issue-operations.md` as part of `IssuesClient`. See ADR-003.
+
+**Dependencies**: `ApiError`, `IssueUser`, `Comment`
 
 ## Overview
 
@@ -80,216 +87,16 @@ pub struct Reaction {
 }
 ```
 
-## Issue Reaction Operations
+## API Endpoints (for reference)
 
-### List Issue Reactions
+| Attachment | Endpoint |
+|-----------|----------|
+| Issue reactions | `GET/POST/DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions[/{id}]` |
+| Comment reactions | `GET/POST/DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions[/{id}]` |
 
-```rust
-impl InstallationClient {
-    /// List all reactions on an issue.
-    ///
-    /// Auto-paginates through all results (see ADR-002).
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    ///
-    /// # Returns
-    ///
-    /// All reactions on the issue, across all pages.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue doesn't exist
-    /// * `ApiError::AuthorizationFailed` - Missing `issues:read`
-    pub async fn list_issue_reactions(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-    ) -> Result<Vec<Reaction>, ApiError>;
-}
-```
-
-**Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/reactions?per_page=100`
-
-### Create Issue Reaction
-
-```rust
-impl InstallationClient {
-    /// Add a reaction to an issue.
-    ///
-    /// If the authenticated user has already reacted with this emoji,
-    /// GitHub returns the existing reaction (200) rather than creating a
-    /// duplicate (201). Both cases return `Ok(Reaction)`.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `content` - The emoji reaction to add
-    ///
-    /// # Returns
-    ///
-    /// The created or existing `Reaction`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue doesn't exist
-    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
-    pub async fn create_issue_reaction(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        content: ReactionContent,
-    ) -> Result<Reaction, ApiError>;
-}
-```
-
-**Endpoint**: `POST /repos/{owner}/{repo}/issues/{issue_number}/reactions`
-**Body**: `{ "content": "+1" }`
-**Success codes**: 200 (already exists) and 201 (created) both succeed.
-
-### Delete Issue Reaction
-
-```rust
-impl InstallationClient {
-    /// Remove a reaction from an issue.
-    ///
-    /// Only the authenticated user can delete their own reactions.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `issue_number` - Issue number
-    /// * `reaction_id` - ID of the reaction to remove
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Issue or reaction doesn't exist
-    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
-    pub async fn delete_issue_reaction(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        reaction_id: u64,
-    ) -> Result<(), ApiError>;
-}
-```
-
-**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}`
-**Success code**: 204 No Content
-
-## Issue Comment Reaction Operations
-
-### List Comment Reactions
-
-```rust
-impl InstallationClient {
-    /// List all reactions on an issue comment.
-    ///
-    /// Auto-paginates through all results (see ADR-002).
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `comment_id` - Comment ID (not the issue number)
-    ///
-    /// # Returns
-    ///
-    /// All reactions on the comment, across all pages.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Comment doesn't exist
-    /// * `ApiError::AuthorizationFailed` - Missing `issues:read`
-    pub async fn list_comment_reactions(
-        &self,
-        owner: &str,
-        repo: &str,
-        comment_id: u64,
-    ) -> Result<Vec<Reaction>, ApiError>;
-}
-```
-
-**Endpoint**: `GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions?per_page=100`
-
-### Create Comment Reaction
-
-```rust
-impl InstallationClient {
-    /// Add a reaction to an issue comment.
-    ///
-    /// If the authenticated user has already reacted with this emoji,
-    /// GitHub returns the existing reaction (200) rather than a duplicate.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `comment_id` - Comment ID (not the issue number)
-    /// * `content` - The emoji reaction to add
-    ///
-    /// # Returns
-    ///
-    /// The created or existing `Reaction`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Comment doesn't exist
-    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
-    pub async fn create_comment_reaction(
-        &self,
-        owner: &str,
-        repo: &str,
-        comment_id: u64,
-        content: ReactionContent,
-    ) -> Result<Reaction, ApiError>;
-}
-```
-
-**Endpoint**: `POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions`
-**Body**: `{ "content": "eyes" }`
-**Success codes**: 200 (already exists) and 201 (created) both succeed.
-
-### Delete Comment Reaction
-
-```rust
-impl InstallationClient {
-    /// Remove a reaction from an issue comment.
-    ///
-    /// Only the authenticated user can delete their own reactions.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `comment_id` - Comment ID (not the issue number)
-    /// * `reaction_id` - ID of the reaction to remove
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::NotFound` - Comment or reaction doesn't exist
-    /// * `ApiError::AuthorizationFailed` - Missing `issues:write`
-    pub async fn delete_comment_reaction(
-        &self,
-        owner: &str,
-        repo: &str,
-        comment_id: u64,
-        reaction_id: u64,
-    ) -> Result<(), ApiError>;
-}
-```
-
-**Endpoint**: `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}`
-**Success code**: 204 No Content
+For method signatures, error mapping, and pagination behaviour see `issue-operations.md`
+(`IssuesClient::list_reactions`, `create_reaction`, `delete_reaction`,
+`list_comment_reactions`, `create_comment_reaction`, `delete_comment_reaction`).
 
 ## Implementation Location
 

--- a/docs/specs/interfaces/repository-operations.md
+++ b/docs/specs/interfaces/repository-operations.md
@@ -1,18 +1,36 @@
-# Repository Operations Interface Specification
+# RepositoriesClient Interface Specification
 
 **Module**: `github-bot-sdk::client::repository`
-**File**: `crates/github-bot-sdk/src/client/repository.rs`
-**Dependencies**: `InstallationClient`, `ApiError`, shared types
+**Struct**: `RepositoriesClient`
+**Obtained via**: `InstallationClient::repositories()`
+**Source files**: `src/client/repository.rs`, `src/client/commit.rs`
+
+See **ADR-003** for the sub-client pattern rationale.
 
 ## Overview
 
-Repository operations provide access to repository metadata, branch management, and Git reference operations. These are installation-scoped operations that require appropriate permissions.
+`RepositoriesClient` provides access to repository metadata, branch management,
+Git reference operations, tags, and commit history. Commit operations are logically
+part of repository operations and live in the same sub-client.
 
-## Architectural Location
+## Sub-Client Type
 
-**Layer**: Infrastructure adapter (GitHub API operations)
-**Purpose**: Repository and Git reference management
-**Required Permissions**: `contents:read` (minimum), `contents:write` (for mutations)
+```rust
+/// Domain client for repository, git-ref, and commit operations.
+///
+/// Obtained via `InstallationClient::repositories()`. Cheap to clone (Arc-backed).
+#[derive(Debug, Clone)]
+pub struct RepositoriesClient {
+    // Internal representation chosen by interface designer
+}
+```
+
+## Permissions
+
+| Operation group | Minimum permission |
+|----------------|--------------------|
+| `get`, list branches/tags/commits, `compare` | `contents: read` |
+| `create_ref`, `update_ref`, `delete_ref`, `create_branch`, `create_tag` | `contents: write` |
 
 ## Core Types
 
@@ -134,34 +152,24 @@ pub struct Tag {
 
 ## Repository Operations
 
-### Get Repository
+### `get`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// Get repository metadata.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner login
-    /// * `repo` - Repository name
-    ///
-    /// # Returns
-    ///
-    /// Returns `Repository` with full metadata.
     ///
     /// # Errors
     ///
-    /// * `ApiError::NotFound` - Repository doesn't exist or not accessible
-    /// * `ApiError::PermissionDenied` - Missing `contents:read` permission
-    /// * `ApiError::HttpError` - Other API errors
+    /// * `ApiError::NotFound` — Repository doesn't exist or is not accessible
+    /// * `ApiError::AuthorizationFailed` — Missing `contents: read`
     ///
     /// # Examples
     ///
     /// ```rust
-    /// let repo = client.get_repository("octocat", "Hello-World").await?;
+    /// let repo = client.repositories().get("octocat", "Hello-World").await?;
     /// println!("Repository: {}", repo.full_name);
     /// ```
-    pub async fn get_repository(
+    pub async fn get(
         &self,
         owner: &str,
         repo: &str,
@@ -169,39 +177,21 @@ impl InstallationClient {
 }
 ```
 
-**Implementation**:
-
-1. Build path: `repos/{owner}/{repo}`
-2. Call `self.get(path)`
-3. Parse JSON response to `Repository`
-4. Map errors appropriately
+**Endpoint**: `GET /repos/{owner}/{repo}`
 
 ## Branch Operations
 
-### List Branches
+### `list_branches`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// List all branches in a repository.
     ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of `Branch` objects.
+    /// Auto-paginates using `per_page=100` (ADR-002).
     ///
     /// # Errors
     ///
-    /// * `ApiError::NotFound` - Repository not found
-    /// * `ApiError::PermissionDenied` - Missing permissions
-    ///
-    /// # Notes
-    ///
-    /// This method returns all branches (not paginated for now).
-    /// Future: Support pagination for repositories with many branches.
+    /// * `ApiError::NotFound` — Repository not found
     pub async fn list_branches(
         &self,
         owner: &str,
@@ -210,25 +200,17 @@ impl InstallationClient {
 }
 ```
 
-### Get Branch
+**Endpoint**: `GET /repos/{owner}/{repo}/branches?per_page=100`
+
+### `get_branch`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// Get a specific branch by name.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `branch` - Branch name
-    ///
-    /// # Returns
-    ///
-    /// Returns `Branch` with commit SHA and protection status.
     ///
     /// # Errors
     ///
-    /// * `ApiError::NotFound` - Branch doesn't exist
+    /// * `ApiError::NotFound` — Branch doesn't exist
     pub async fn get_branch(
         &self,
         owner: &str,
@@ -238,23 +220,17 @@ impl InstallationClient {
 }
 ```
 
+**Endpoint**: `GET /repos/{owner}/{repo}/branches/{branch}`
+
 ## Git Reference Operations
 
-### Get Git Reference
+### `get_ref`
 
 ```rust
-impl InstallationClient {
-    /// Get a Git reference (branch or tag).
+impl RepositoriesClient {
+    /// Get a Git reference (branch head or tag).
     ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `ref_name` - Reference name (e.g., "heads/main", "tags/v1.0.0")
-    ///
-    /// # Returns
-    ///
-    /// Returns `GitRef` with SHA and metadata.
+    /// `ref_name` examples: `"heads/main"`, `"tags/v1.0.0"`
     ///
     /// # Errors
     ///
@@ -263,14 +239,10 @@ impl InstallationClient {
     /// # Examples
     ///
     /// ```rust
-    /// // Get main branch reference
-    /// let git_ref = client.get_git_ref("octocat", "Hello-World", "heads/main").await?;
-    /// println!("SHA: {}", git_ref.object.sha);
-    ///
-    /// // Get tag reference
-    /// let tag_ref = client.get_git_ref("octocat", "Hello-World", "tags/v1.0.0").await?;
+    /// let r = client.repositories().get_ref("octocat", "Hello-World", "heads/main").await?;
+    /// println!("SHA: {}", r.object.sha);
     /// ```
-    pub async fn get_git_ref(
+    pub async fn get_ref(
         &self,
         owner: &str,
         repo: &str,
@@ -279,40 +251,30 @@ impl InstallationClient {
 }
 ```
 
-### Create Git Reference
+**Endpoint**: `GET /repos/{owner}/{repo}/git/refs/{ref_name}`
+
+### `create_ref`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// Create a new Git reference (branch or tag).
     ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `ref_name` - Full reference name (e.g., "refs/heads/feature-branch")
-    /// * `sha` - Commit SHA to point reference at
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `GitRef`.
+    /// `ref_name` must be fully qualified, e.g. `"refs/heads/feature-branch"`.
     ///
     /// # Errors
     ///
-    /// * `ApiError::PermissionDenied` - Missing `contents:write` permission
-    /// * `ApiError::HttpError` - Reference already exists (422)
+    /// * `ApiError::AuthorizationFailed` - Missing `contents: write`
+    /// * `ApiError::InvalidRequest` - Reference already exists (422)
     /// * `ApiError::NotFound` - SHA doesn't exist
     ///
     /// # Examples
     ///
     /// ```rust
-    /// let git_ref = client.create_git_ref(
-    ///     "octocat",
-    ///     "Hello-World",
-    ///     "refs/heads/new-feature",
-    ///     "abc123def456",
-    /// ).await?;
+    /// let r = client.repositories()
+    ///     .create_ref("octocat", "Hello-World", "refs/heads/new-feature", "abc123")
+    ///     .await?;
     /// ```
-    pub async fn create_git_ref(
+    pub async fn create_ref(
         &self,
         owner: &str,
         repo: &str,
@@ -322,29 +284,19 @@ impl InstallationClient {
 }
 ```
 
-### Update Git Reference
+**Endpoint**: `POST /repos/{owner}/{repo}/git/refs`
+
+### `update_ref`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// Update an existing Git reference.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `ref_name` - Reference name (e.g., "heads/main")
-    /// * `sha` - New commit SHA
-    /// * `force` - Whether to force update (allows non-fast-forward)
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `GitRef`.
     ///
     /// # Errors
     ///
-    /// * `ApiError::PermissionDenied` - Missing `contents:write`
-    /// * `ApiError::HttpError` - Non-fast-forward without force (422)
-    pub async fn update_git_ref(
+    /// * `ApiError::AuthorizationFailed` - Missing `contents: write`
+    /// * `ApiError::InvalidRequest` - Non-fast-forward without `force` (422)
+    pub async fn update_ref(
         &self,
         owner: &str,
         repo: &str,
@@ -355,23 +307,19 @@ impl InstallationClient {
 }
 ```
 
-### Delete Git Reference
+**Endpoint**: `PATCH /repos/{owner}/{repo}/git/refs/{ref_name}`
+
+### `delete_ref`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// Delete a Git reference.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `ref_name` - Reference name (e.g., "heads/feature-branch")
     ///
     /// # Errors
     ///
-    /// * `ApiError::PermissionDenied` - Missing `contents:write`
+    /// * `ApiError::AuthorizationFailed` - Missing `contents: write`
     /// * `ApiError::NotFound` - Reference doesn't exist
-    pub async fn delete_git_ref(
+    pub async fn delete_ref(
         &self,
         owner: &str,
         repo: &str,
@@ -380,27 +328,18 @@ impl InstallationClient {
 }
 ```
 
+**Endpoint**: `DELETE /repos/{owner}/{repo}/git/refs/{ref_name}`
+**Success**: 204 No Content
+
 ## Tag Operations
 
-### List Tags
+### `list_tags`
 
 ```rust
-impl InstallationClient {
+impl RepositoriesClient {
     /// List all tags in a repository.
     ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    ///
-    /// # Returns
-    ///
-    /// Returns vector of `Tag` objects.
-    ///
-    /// # Notes
-    ///
-    /// Returns all tags (not paginated).
-    /// Future: Support pagination for repos with many tags.
+    /// Auto-paginates using `per_page=100` (ADR-002).
     pub async fn list_tags(
         &self,
         owner: &str,
@@ -409,41 +348,33 @@ impl InstallationClient {
 }
 ```
 
-## Convenience Methods for Branch and Tag Creation
+**Endpoint**: `GET /repos/{owner}/{repo}/tags?per_page=100`
 
-These methods provide a more intuitive API for common operations, wrapping the lower-level `create_git_ref` method.
+## Convenience Methods
 
-### Create Branch
+### `create_branch`
+
+Convenience wrapper around `create_ref` for branch creation.
 
 ```rust
-impl InstallationClient {
-    /// Create a new branch.
+impl RepositoriesClient {
+    /// Create a new branch from a commit SHA.
     ///
-    /// Convenience wrapper around `create_git_ref` for branch creation.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `branch_name` - Name of the new branch (without "refs/heads/" prefix)
-    /// * `from_sha` - Commit SHA to create the branch from
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `GitRef`.
+    /// `branch_name` is the short name (without `refs/heads/` prefix).
     ///
     /// # Errors
     ///
-    /// * `ApiError::PermissionDenied` - Missing `contents:write` permission
-    /// * `ApiError::HttpError` - Branch already exists (422)
+    /// * `ApiError::AuthorizationFailed` - Missing `contents: write`
+    /// * `ApiError::InvalidRequest` - Branch already exists (422)
     /// * `ApiError::NotFound` - SHA doesn't exist
     ///
     /// # Examples
     ///
     /// ```rust
-    /// // Create new branch from main
-    /// let main = client.get_branch("owner", "repo", "main").await?;
-    /// let branch = client.create_branch("owner", "repo", "feature", &main.commit.sha).await?;
+    /// let main = client.repositories().get_branch("owner", "repo", "main").await?;
+    /// let branch = client.repositories()
+    ///     .create_branch("owner", "repo", "feature", &main.commit.sha)
+    ///     .await?;
     /// ```
     pub async fn create_branch(
         &self,
@@ -455,45 +386,23 @@ impl InstallationClient {
 }
 ```
 
-**Implementation**: Calls `self.create_git_ref(owner, repo, &format!("refs/heads/{}", branch_name), from_sha)`
+**Implementation**: Calls `self.create_ref(owner, repo, &format!("refs/heads/{branch_name}"), from_sha)`
 
-### Create Tag
+### `create_tag`
+
+Convenience wrapper around `create_ref` for lightweight tag creation.
 
 ```rust
-impl InstallationClient {
-    /// Create a new lightweight tag.
+impl RepositoriesClient {
+    /// Create a new lightweight tag pointing at a commit SHA.
     ///
-    /// Convenience wrapper around `create_git_ref` for tag creation.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - Repository owner
-    /// * `repo` - Repository name
-    /// * `tag_name` - Name of the new tag (without "refs/tags/" prefix)
-    /// * `from_sha` - Commit SHA to tag
-    ///
-    /// # Returns
-    ///
-    /// Returns the created `GitRef`.
-    ///
-    /// # Errors
-    ///
-    /// * `ApiError::PermissionDenied` - Missing `contents:write` permission
-    /// * `ApiError::HttpError` - Tag already exists (422)
-    /// * `ApiError::NotFound` - SHA doesn't exist
+    /// For annotated tags, use the Git Data API (not currently implemented).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// // Create release tag
-    /// let commit_sha = "abc123def456";
-    /// let tag = client.create_tag("owner", "repo", "v1.0.0", commit_sha).await?;
+    /// client.repositories().create_tag("owner", "repo", "v1.0.0", sha).await?;
     /// ```
-    ///
-    /// # Notes
-    ///
-    /// This creates a lightweight tag. For annotated tags with messages,
-    /// use the Git Data API (not currently implemented).
     pub async fn create_tag(
         &self,
         owner: &str,
@@ -504,58 +413,70 @@ impl InstallationClient {
 }
 ```
 
-**Implementation**: Calls `self.create_git_ref(owner, repo, &format!("refs/tags/{}", tag_name), from_sha)`
+**Implementation**: Calls `self.create_ref(owner, repo, &format!("refs/tags/{tag_name}"), from_sha)`
 
-## Request Body Types
+## Commit Operations
 
-### CreateGitRefRequest
+### `get_commit`
 
 ```rust
-#[derive(Debug, Serialize)]
-struct CreateGitRefRequest {
-    #[serde(rename = "ref")]
-    ref_name: String,
-    sha: String,
+impl RepositoriesClient {
+    /// Get full commit details by SHA.
+    pub async fn get_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<FullCommit, ApiError>;
 }
 ```
 
-### UpdateGitRefRequest
+**Endpoint**: `GET /repos/{owner}/{repo}/commits/{sha}`
+
+### `list_commits`
 
 ```rust
-#[derive(Debug, Serialize)]
-struct UpdateGitRefRequest {
-    sha: String,
-    force: bool,
+impl RepositoriesClient {
+    /// List commits on a branch, optionally scoped to a file path.
+    ///
+    /// Returns a single page of results (manual pagination — commit history
+    /// can be arbitrarily large, ADR-002).
+    pub async fn list_commits(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+        path: Option<&str>,
+        page: u32,
+    ) -> Result<PagedResponse<CommitDetails>, ApiError>;
 }
 ```
 
-## Error Handling
+**Endpoint**: `GET /repos/{owner}/{repo}/commits?sha={branch}&path={path}&page={page}&per_page=30`
 
-### Permission Errors
+### `compare`
 
-Operations requiring `contents:write`:
+```rust
+impl RepositoriesClient {
+    /// Compare two commits or refs to get the diff and divergence info.
+    pub async fn compare(
+        &self,
+        owner: &str,
+        repo: &str,
+        base: &str,
+        head: &str,
+    ) -> Result<Comparison, ApiError>;
+}
+```
 
-- `create_git_ref`
-- `update_git_ref`
-- `delete_git_ref`
-
-All return `ApiError::PermissionDenied` with 403 status.
-
-### Not Found Errors
-
-Return `ApiError::NotFound` (404) when:
-
-- Repository doesn't exist
-- Branch doesn't exist
-- Reference doesn't exist
-- Installation doesn't have access
+**Endpoint**: `GET /repos/{owner}/{repo}/compare/{base}...{head}`
 
 ## Usage Examples
 
 ### Get Repository Metadata
 
 ```rust
-let repo = client.get_repository("octocat", "Hello-World").await?;
+let repo = client.repositories().get("octocat", "Hello-World").await?;
 println!("Default branch: {}", repo.default_branch);
 println!("Created: {}", repo.created_at);
 ```
@@ -563,23 +484,15 @@ println!("Created: {}", repo.created_at);
 ### Create a New Branch
 
 ```rust
-// Get current main branch SHA
-let main_branch = client.get_branch("octocat", "Hello-World", "main").await?;
-let sha = main_branch.commit.sha;
-
-// Create new branch pointing at same SHA
-let new_ref = client.create_git_ref(
-    "octocat",
-    "Hello-World",
-    "refs/heads/feature-branch",
-    &sha,
-).await?;
+let repos = client.repositories();
+let main = repos.get_branch("octocat", "Hello-World", "main").await?;
+let _branch = repos.create_branch("octocat", "Hello-World", "feature", &main.commit.sha).await?;
 ```
 
 ### List All Tags
 
 ```rust
-let tags = client.list_tags("octocat", "Hello-World").await?;
+let tags = client.repositories().list_tags("octocat", "Hello-World").await?;
 for tag in tags {
     println!("Tag: {} -> {}", tag.name, tag.commit.sha);
 }

--- a/docs/specs/responsibilities.md
+++ b/docs/specs/responsibilities.md
@@ -143,6 +143,44 @@ This document defines the responsibilities of components within the GitHub Bot S
 
 **Responsibilities:**
 
+- **Knows**: Issue metadata, labels, assignees, comments, milestones, reactions, lock state
+- **Does**: Creates/updates issues, manages comments (with auto-pagination), handles assignees,
+  labels, reactions, locking, milestones, and timeline/activity-event retrieval
+
+**Collaborators:**
+
+- `GitHubApiClient` (executes issue API calls)
+- `PaginationHelper` (drives auto-pagination loop for comment/event/reaction lists)
+
+**Roles:**
+
+- **Issue Lifecycle Manager**: Handles the complete issue workflow (open → close)
+- **Comment Manager**: Creates, updates, deletes, and paginated-lists issue comments
+- **Moderation Controller**: Locks and unlocks issues via the admin lock API
+- **Assignment Coordinator**: Adds, removes, and queries assignees per-issue
+- **Label Coordinator**: Adds, removes, replaces, and queries labels on issues
+- **Reaction Handler**: Creates, lists, and deletes emoji reactions on issues and comments
+- **Milestone CRUD**: Creates, updates, deletes, and lists milestones in a repository
+- **Timeline Reader**: Retrieves complete issue activity events and full timeline for audit trails
+
+### ReactionOperations
+
+**Responsibilities:**
+
+- **Knows**: Emoji reaction content types, reaction IDs, per-user reaction state
+- **Does**: Creates (idempotently), lists (auto-paginated), and deletes reactions on
+  issues and issue comments
+
+**Collaborators:**
+
+- `GitHubApiClient` (executes reaction API calls)
+- `PaginationHelper` (drives auto-pagination)
+
+**Roles:**
+
+- **Signal Emitter**: Provides lightweight emoji acknowledgements without comment noise
+- **Idempotency Handler**: Treats HTTP 200 (duplicate) and HTTP 201 (new) as identical success
+
 - **Knows**: Issue metadata, labels, assignees, comments
 - **Does**: Creates/updates issues, manages labels, handles assignments
 

--- a/docs/specs/vocabulary.md
+++ b/docs/specs/vocabulary.md
@@ -248,6 +248,104 @@ Test doubles that simulate GitHub App authentication without real API calls.
 
 Sample GitHub webhook events used for testing bot behavior.
 
+## Issue Domain Concepts (Extended)
+
+### Issue Comment
+
+A text reply attached to an issue. Key to bot automation because bots post, read, and
+search comments to store state, communicate with humans, and implement mutual exclusion.
+
+- **ID**: Numeric comment identifier (unique across the repository, not just the issue)
+- **Body**: Markdown text; bots commonly embed structured prefixes for programmatic parsing
+- **Author**: Login of the user or bot that created the comment
+- **Created At**: UTC timestamp; ascending order (oldest first) is the GitHub default
+- **Auto-pagination**: `list_issue_comments()` must fetch all pages to produce a
+  correct result for state-reconstruction and lock-detection use cases (see ADR-002)
+
+### Reaction
+
+An emoji acknowledgement attached to an issue or issue comment by a GitHub user.
+
+- **Content**: One of eight emoji: 👍 (`+1`), 👎 (`-1`), 😄 (`laugh`), 😕 (`confused`),
+  ❤️ (`heart`), 🎉 (`hooray`), 🚀 (`rocket`), 👀 (`eyes`)
+- **Idempotent creation**: GitHub returns the existing reaction (200) if the user has
+  already reacted with the same emoji; no duplicate is created.
+- **Scope**: Reactions exist independently on issues and on individual comments.
+- **Bot use**: Bots use 👀 to signal "I received this" and ✅/❌ (via labels or comments)
+  for outcome signalling.
+
+### Issue Lock
+
+A moderation state that prevents non-collaborator comments on an issue.
+
+- **Lock Reason**: Optional; one of `off-topic`, `too-heated`, `resolved`, `spam`
+- **Effect**: Only users with write access (collaborators) can comment while locked
+- **Reversible**: Can be unlocked at any time by someone with admin or maintain permission
+- **Webhook**: Lock/unlock actions appear in the `IssueEvent` webhook and in the
+  issue activity event stream
+
+### Assignee
+
+A GitHub user who is responsible for an issue.
+
+- **Eligible users**: Only collaborators, org members with triage access, or repo contributors
+  can be assigned. `list_available_assignees()` returns the eligible set.
+- **Multiple**: Issues can have zero or more assignees simultaneously.
+- **Bot use**: Bots auto-assign issues based on routing rules (area, round-robin, etc.)
+- **Idempotent**: Adding an already-assigned user is a no-op (GitHub ignores it silently)
+
+### Milestone
+
+A named target grouping open and closed issues toward a shared goal.
+
+- **Number**: Repository-scoped integer; used in API calls (not the global ID)
+- **State**: `open` or `closed`
+- **Due On**: Optional UTC timestamp; bots use this for release deadline tracking
+- **Issue counts**: GitHub tracks `open_issues` and `closed_issues` on the milestone object
+- **Detach**: Setting `milestone: null` on an issue removes it from the milestone
+
+### Issue Activity Event
+
+A discrete historical record of a state change on an issue, returned by the issue events
+REST endpoint. Different from a **GitHub Webhook Event** (which is a push notification).
+
+- **Examples**: `labeled`, `unlabeled`, `assigned`, `unassigned`, `milestoned`,
+  `demilestoned`, `closed`, `reopened`, `renamed`, `locked`, `unlocked`, `referenced`
+- **Ordering**: Ascending chronological order
+- **Use case**: Audit trails, historical state reconstruction, debugging bot behaviour
+- **Not comments**: Comments do not appear in this stream; use the timeline endpoint for those
+
+### Issue Timeline
+
+A superset of issue activity events that also includes comments, cross-references,
+review events, and commit references. Returns a heterogeneous ordered sequence.
+
+- **Endpoint**: `GET /repos/{owner}/{repo}/issues/{issue_number}/timeline`
+- **Items**: Mixed types identified by the `event` field on each object
+- **Use case**: Complete audit trail, full state reconstruction, cross-reference tracking
+- **Unknown kinds**: Unknown event types must deserialize gracefully to a catch-all variant
+
+### IssueCommentEvent (Webhook)
+
+A webhook event fired by GitHub when a comment on an issue is created, edited, or deleted.
+Not to be confused with the REST API issue activity stream.
+
+- **Header**: `X-GitHub-Event: issue_comment`
+- **Actions**: `created`, `edited`, `deleted`
+- **Payload**: Contains both the parent `issue` and the `comment` that changed
+- **Distinction**: The `issues` webhook covers issue lifecycle; `issue_comment` covers
+  comment lifecycle on issues only (not PR comments, which use `pull_request_review_comment`)
+
+### Auto-Pagination
+
+A pagination strategy where the SDK follows all `Link: rel="next"` headers automatically,
+returning a complete `Vec<T>` rather than a page-at-a-time `PagedResponse<T>`.
+
+- **When used**: For operations where callers need the complete set (see ADR-002)
+- **Page size**: `per_page=100` (GitHub maximum) to minimise round trips
+- **Memory**: All items are held in memory; appropriate for bounded collections
+- **Contrast**: `list_issues()` uses manual paging because the caller may stop early
+
 - **Representative**: Cover common GitHub event types and actions
 - **Edge Cases**: Include malformed or unusual event structures
 - **Complete**: Full event payloads with all relevant fields
@@ -329,6 +427,86 @@ A description of how a single file changed in a comparison.
 - **Changes**: Total lines changed (additions + deletions)
 - **Previous Filename**: Original path if file was renamed
 - **Patch**: Unified diff showing exact changes (may be truncated for large diffs)
+
+## Sub-Client API Concepts (ADR-003)
+
+### Domain Sub-Client
+
+A lightweight struct that groups GitHub API methods for a single business domain
+(issues, pull requests, labels, milestones, etc.) and is obtained from `InstallationClient`
+via an infallible factory method (`client.issues()`, `client.labels()`, etc.).
+
+- **Construction**: No API call; O(1) cost (at most an `Arc` increment)
+- **Lifetime**: Sub-clients can be stored, cloned, and passed across async tasks
+- **Scope**: Each sub-client covers exactly one business domain
+- **Delegation**: All HTTP calls go through the parent `InstallationClient`'s generic helpers
+- **Rationale**: Avoids placing 85+ methods on one type; groups related operations for discoverability
+
+### IssuesClient
+
+The domain sub-client for GitHub issues. Covers issue CRUD, comments, reactions,
+label application, assignees, locking, milestone assignment, and timeline queries.
+
+- **Obtained via**: `InstallationClient::issues()`
+- **Source file**: `src/client/issue.rs`
+
+### LabelsClient
+
+The domain sub-client for the **repository-level label catalogue**. Manages the
+`Label` definitions that exist in a repository (`list`, `get`, `create`, `update`, `delete`).
+
+- **Distinct from**: Applying labels to individual issues (→ `IssuesClient`) or PRs (→ `PullRequestsClient`)
+- **Obtained via**: `InstallationClient::labels()`
+- **Source file**: `src/client/issue.rs`
+
+### MilestonesClient
+
+The domain sub-client for milestone lifecycle management. Covers `list`, `get`, `create`,
+`update`, and `delete` of milestone definitions.
+
+- **Distinct from**: Assigning a milestone to an issue (→ `IssuesClient::set_milestone`) or PR (→ `PullRequestsClient::set_milestone`)
+- **Obtained via**: `InstallationClient::milestones()`
+- **Source file**: `src/client/issue.rs`
+
+### PullRequestsClient
+
+The domain sub-client for pull requests. Covers PR CRUD, reviews, conversation-thread
+comments, label application, and milestone assignment.
+
+- **Obtained via**: `InstallationClient::pull_requests()`
+- **Source file**: `src/client/pull_request.rs`
+
+### RepositoriesClient
+
+The domain sub-client for repository metadata, branch management, Git references,
+tags, and commit history.
+
+- **Obtained via**: `InstallationClient::repositories()`
+- **Source files**: `src/client/repository.rs`, `src/client/commit.rs`
+
+### WorkflowsClient
+
+The domain sub-client for GitHub Actions workflows and runs (`list`, `get`, `trigger`,
+`list_runs`, `get_run`, `cancel_run`, `rerun_run`).
+
+- **Obtained via**: `InstallationClient::workflows()`
+- **Source file**: `src/client/workflow.rs`
+
+### ReleasesClient
+
+The domain sub-client for GitHub Releases (`list`, `get`, `get_latest`, `get_by_tag`,
+`create`, `update`, `delete`).
+
+- **Obtained via**: `InstallationClient::releases()`
+- **Source file**: `src/client/release.rs`
+
+### ProjectsClient
+
+The domain sub-client for GitHub Projects V2 (`list_for_org`, `list_for_user`, `get`,
+`add_item`, `remove_item`, `list_for_issue`).
+
+- **Obtained via**: `InstallationClient::projects()`
+- **Source file**: `src/client/project.rs`
 
 ### Git Signature
 


### PR DESCRIPTION
Introduces architecture specifications for a domain sub-client API pattern and a full suite
of issue-area extensions, resolving the API consistency problem identified in issue #39 and
designing all related GitHub operations needed for state reconstruction and lock detection.

references #39

## What Changed

- Added ADR-002 (auto-pagination strategy): defines which operations return `Vec<T>` via
  automatic link-header following vs. `PagedResponse<T>` for manual pagination.
- Added ADR-003 (domain sub-client pattern): replaces the flat `InstallationClient` method
  surface (85+ methods) with 8 focused domain clients (`IssuesClient`, `LabelsClient`,
  `MilestonesClient`, `PullRequestsClient`, `RepositoriesClient`, `WorkflowsClient`,
  `ReleasesClient`, `ProjectsClient`) accessed via infallible factory methods.
- Rewrote `issue-operations.md` as `IssuesClient` spec (28 methods) covering issue CRUD,
  full comment CRUD, reactions, assignees, locking, milestone assignment, activity events,
  and timeline queries.
- Added `labels-client.md`: `LabelsClient` for repository-level label catalogue management.
- Added `milestones-client.md`: `MilestonesClient` for milestone lifecycle CRUD.
- Added `reactions.md`: shared `ReactionContent` and `Reaction` types with serde rename
  constraints for the `+1` / `-1` emoji variants.
- Updated `pull-request-operations.md` as `PullRequestsClient` spec: renamed all methods,
  filled the missing `update_comment` / `delete_comment` gap, and corrected review naming.
- Updated `repository-operations.md` as `RepositoriesClient` spec: renamed git-ref methods
  (`get_git_ref` → `get_ref`, etc.) and folded commit operations into the same sub-client.
- Updated `installation-client.md` with all 8 factory method signatures and construction
  constraints (infallible, O(1), no API call).
- Updated `interfaces/README.md` with a full sub-client dependency graph and method rename
  mapping table.
- Extended `vocabulary.md` with sub-client concept definitions and issue domain concepts
  (IssueComment, Reaction, IssueLock, Assignee, Milestone, IssueActivityEvent, etc.).
- Extended `constraints.md` with sub-client structural rules, file placement table, label
  responsibility split, naming rules, and the full pagination policy table.
- Extended `assertions.md` (assertions 38–59), `edge-cases.md` (cases 17–24), and
  `responsibilities.md` with the new operations.

## Why

Issue #39 requested `issues().list_comments()` for the `cog_works` pipeline, where complete
comment history is needed for state reconstruction and distributed lock detection. An API
audit revealed that the underlying problem was broader: all methods were flat on
`InstallationClient` with no domain grouping, inconsistent naming (e.g., reviews and repo
label management had no domain prefix), and functional gaps (missing PR comment
update/delete). This PR addresses the root cause by specifying a clean domain sub-client API
before any new code is written.

## How

The sub-client pattern (ADR-003) introduces lightweight structs obtained via factory methods.
Each sub-client delegates all HTTP calls back to the parent `InstallationClient`, so token
caching and rate limiting remain centralised. The factory methods are infallible and O(1);
no API call is made at construction time.

The label split is the key design decision: `LabelsClient` manages label *definitions* in
the repository catalogue, while `IssuesClient` and `PullRequestsClient` manage label
*application* on specific issues and PRs respectively, mirroring GitHub's own endpoint
structure.

Auto-pagination (ADR-002) is applied to bounded collections (label catalogue, milestone
list, reactions, comment list) and to any operation where callers need a complete result
set (issue comments for state reconstruction, timeline for audit). Manual pagination is
preserved for unbounded collections (issue list, PR list, commit history).

## Testing Evidence

- **Test Coverage:** No source code is changed in this PR — all changes are specification
  and architecture documentation only. Test scenarios are captured in the updated
  `assertions.md` and `edge-cases.md` and will guide test authorship during implementation.
- **Test Results:** N/A (documentation only)
- **Manual Testing:** N/A (documentation only)

## Reviewer Guidance

- The key design decision to review is the label responsibility split: `LabelsClient` for
  catalogue definitions vs. `IssuesClient`/`PullRequestsClient` for label application. This
  mirrors the GitHub API endpoint structure and avoids ambiguity.
- Review the pagination policy table in `constraints.md` — specifically which operations
  are auto-paginated vs. manual — as this drives memory and performance characteristics.
- ADR-003 records the rationale for Option A (flat methods within each sub-client rather
  than further nesting); reviewers should confirm this matches the desired developer
  ergonomics.
- The `ReactionContent::PlusOne` / `MinusOne` serde rename constraint (`"+1"` / `"-1"`)
  in `reactions.md` is a GitHub API quirk that must carry through to the implementation.
- Breaking change: the old flat `InstallationClient` methods will be removed when these
  specs are implemented. There is no compatibility shim (noted in `constraints.md`).

## Reviewer Guidance

- **`post_graphql` error-handling logic** (`installation.rs`): review the order
  of the `.errors[]` check, the `NOT_FOUND` type mapping, and the missing-data
  guard. This is the only place where GraphQL application-level errors are
  translated to `ApiError` variants.
- **`get_project_node_id` fallback** (`project.rs`): the org-first then
  user-fallback pattern is necessary because no endpoint reveals whether an
  owner is an org or a user given only a login string. Verify the fallback
  triggers only on `ApiError::NotFound` (not on other errors).
- **`map_project_node` owner defaults** (`project.rs`): `owner.databaseId` and
  `owner.id` use `unwrap_or(0)` / `unwrap_or("")` as defensive defaults. The
  query always selects these fields, so the defaults are unreachable in
  practice; comments explain this inline.
- No breaking changes to existing public API. All pre-existing public methods
  are unchanged.