### PR TITLE
fix(changelog): add remote.github section to cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,6 +1,10 @@
 # git-cliff ~ configuration file
 # https://git-cliff.org/docs/configuration
 
+[remote.github]
+owner = "pvandervelde"
+repo = "github-bot-sdk"
+
 [changelog]
 # template for the changelog footer
 header = """


### PR DESCRIPTION
The footer template references remote.github.owner and remote.github.repo but the [remote.github] section was missing, causing release-plz to fail when generating the changelog.