### PR TITLE
fix(client): delegate 4xx error mapping in execute_with_retry to map_http_error

### DIFF
--- a/src/client/installation.rs
+++ b/src/client/installation.rs
@@ -202,17 +202,9 @@ impl InstallationClient {
                     // Check for other client errors (4xx except 429 and 403 which are handled above)
                     // These are non-retryable - map to appropriate error types
                     if (400..500).contains(&status) {
-                        let body = response.text().await.unwrap_or_default();
-                        return Err(match status {
-                            401 => ApiError::AuthenticationFailed,
-                            403 => ApiError::AuthorizationFailed, // Permission denied (not rate limit)
-                            404 => ApiError::NotFound,
-                            422 => ApiError::InvalidRequest { message: body },
-                            _ => ApiError::HttpError {
-                                status,
-                                message: body,
-                            },
-                        });
+                        let status_code = reqwest::StatusCode::from_u16(status)
+                            .unwrap_or(reqwest::StatusCode::BAD_REQUEST);
+                        return Err(super::map_http_error(status_code, response).await);
                     }
 
                     // Success (2xx or 3xx)


### PR DESCRIPTION
The inline match block duplicated the same four status-code mappings already present in map_http_error (401/403/404/422). Replacing it with a single call to super::map_http_error removes the duplication, so any future change to error mapping only needs to be made in one place.

Closes #46