### PR TITLE
fix(ci): install typos in release-plz workflow to fix changelog generation

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -36,6 +36,11 @@ jobs:
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+            - name: Install typos
+              uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2
+              with:
+                  tool: typos
+
             - name: Run release-plz
               uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
               with:


### PR DESCRIPTION
## Problem

The release-plz PR workflow was producing an empty changelog because \git-cliff\ could not generate entries.

\cliff.toml\ uses a commit preprocessor that calls \	ypos\:
\\\	oml
{ pattern = '.*', replace_command = 'typos --write-changes -' },
\\\

\	ypos\ is not installed by default on GitHub-hosted runners, so git-cliff silently failed to process any commits, leaving the changelog blank.

## Fix

Install \	ypos\ via \	aiki-e/install-action\ (already used in \ci.yml\) before the \elease-plz\ step runs.