### PR TITLE
fix(config): remove cliff.toml body rule that silently drops commits with blank lines

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -86,7 +86,6 @@ commit_parsers = [
     { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
     { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
     { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
-    { body = "$^", skip = true },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false


### PR DESCRIPTION
## Problem

The \cliff.toml\ \commit_parsers\ contained:
\\\	oml
{ body = "$^", skip = true },
\\\

In git-cliff's multiline regex mode, \\git\ matches at the boundary between two newlines — i.e., any blank line inside a commit body. Merge commits with long multi-section PR descriptions (blank lines between \## What Changed\, \## Why\, etc. sections) were silently skipped.

This is why commit 521fd737 (the sub-client API feature, PR #41) was missing from the release-plz changelog: its body has multiple blank-line-separated sections, which matched \\git\ and got the commit dropped.

Individual constituent commits of that same PR (which had short single-paragraph bodies) were included fine.

## Fix

Remove the rule entirely. \ilter_commits = true\ and \ilter_unconventional = true\ already handle excluding unwanted commits — the body rule was not needed.