### PR TITLE
fix(config): add use_merge_commit=true so feat PR merges appear in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -59,6 +59,8 @@ postprocessors = [
 conventional_commits = true
 # filter out the commits that are not conventional
 filter_unconventional = true
+# include merge commits (GitHub PR merge commits carry the feat/fix prefix)
+use_merge_commit = true
 # process each line of a commit as an individual commit
 split_commits = false
 # regex for preprocessing the commit messages


### PR DESCRIPTION
## Problem

git-cliff skips merge commits by default in recent versions. GitHub PRs merged with a merge commit carry the conventional commit prefix (feat, fix) on the **merge commit subject**, not on any individual constituent commit.

Without use_merge_commit = true in cliff.toml, those prefixes are invisible to git-cliff and the feature entry is omitted from the changelog.

This is why the feat(client) sub-client API entry (PR #41, commit 521fd73) is absent from the release-plz changelog even after the previous two fixes (typos preprocessor and body skip-rule).

The runner uses a newer git-cliff version bundled in release-plz that changed the default to skip merge commits. Local git-cliff v2.7.0 still included them, masking the issue during local testing.

## Fix

Add use_merge_commit = true to the [git] section of cliff.toml.