### PR TITLE
fix(config): replace use_merge_commit with ignore_merge_commits=false

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -60,7 +60,7 @@ conventional_commits = true
 # filter out the commits that are not conventional
 filter_unconventional = true
 # include merge commits (GitHub PR merge commits carry the feat/fix prefix)
-use_merge_commit = true
+ignore_merge_commits = false
 # process each line of a commit as an individual commit
 split_commits = false
 # regex for preprocessing the commit messages


### PR DESCRIPTION
## Problem

The previous fix (#75) used use_merge_commit = true which is not a valid git-cliff option and was silently ignored.

The real setting is ignore_merge_commits, which defaults to true in git-cliff 2.12.0 (bundled in release-plz). This causes GitHub PR merge commits carrying feat/fix prefixes to be dropped from the changelog.

## Fix

Set ignore_merge_commits = false so merge commits are included.