### PR TITLE
fix(release-plz): checkout merge commit SHA when tagging releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,6 +34,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
+                  ref: ${{ github.event.pull_request.merge_commit_sha }}
                   token: ${{ steps.generate-token.outputs.token }}
 
             - name: Install Rust toolchain


### PR DESCRIPTION
The `pull_request: closed` trigger causes `actions/checkout` to default to `refs/pull/N/merge` -- a synthetic GitHub ref -- rather than the actual merge commit on `master`. Release-plz reads `HEAD` to place its tag, so version tags were landing on the synthetic commit instead of the real one.

Fix: pass `ref: github.event.pull_request.merge_commit_sha` to the checkout step, pinning `HEAD` to the commit that was actually merged into `master`.